### PR TITLE
Refactor/kdl datatypes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: generic
 env:
   - ROS_DISTRO=indigo
   - ROS_DISTRO=jade
+  - ROS_DISTRO=kinetic
 notifications:
   email:
     on_success: change # [always|never|change], default=change

--- a/challenge_following_and_guiding/src/challenge_following_and_guiding.py
+++ b/challenge_following_and_guiding/src/challenge_following_and_guiding.py
@@ -66,8 +66,6 @@ class WaitForOperatorCommand(smach.State):
         # Stop the base
         self._robot.base.local_planner.cancelCurrentPlan()
 
-        base_pose = self._robot.base.get_location()
-
         self._robot.head.look_at_standing_person()
 
         self._robot.speech.speak("Should I guide you back?")

--- a/challenge_manipulation/package.xml
+++ b/challenge_manipulation/package.xml
@@ -19,5 +19,6 @@
   <run_depend>python-markdown</run_depend>
   <run_depend>python-xhtml2pdf</run_depend>
   <run_depend>python-pillow</run_depend>
+  <run_depend>python-numpy</run_depend>
 
 </package>

--- a/challenge_manipulation/src/empty_shelf_designator.py
+++ b/challenge_manipulation/src/empty_shelf_designator.py
@@ -6,7 +6,7 @@ from robot_smach_states.util.designators import Designator
 import geometry_msgs.msg as gm
 from visualization_msgs.msg import MarkerArray, Marker
 import robot_skills.util.msg_constructors as msg_constructors
-from robot_skills.util.kdl_conversions import poseMsgToKdlFrame
+from robot_skills.util.kdl_conversions import FrameStamped, poseMsgToKdlFrame, kdlFrameStampedFromPoseStampedMsg
 import PyKDL as kdl
 import copy
 
@@ -32,7 +32,7 @@ class EmptyShelfDesignator(Designator):
         :param name: name for introspection purposes
         :param area: (optional) area where the item should be placed
         """
-        super(EmptyShelfDesignator, self).__init__(resolve_type=(kdl.Frame, str), name=name)
+        super(EmptyShelfDesignator, self).__init__(resolve_type=FrameStamped, name=name)
         self.robot = robot
 
         if area is None:
@@ -82,7 +82,7 @@ class EmptyShelfDesignator(Designator):
             ret = points_of_interest[self._count]
             self._count += 1
             rospy.loginfo("Place pose at: {0}".format(ret))
-            return poseMsgToKdlFrame(ret.pose), "/map"
+            return kdlFrameStampedFromPoseStampedMsg(ret)
 
 
     def create_marker(self, x, y, z, frame_id="/map"):

--- a/challenge_manipulation/src/empty_shelf_designator.py
+++ b/challenge_manipulation/src/empty_shelf_designator.py
@@ -144,11 +144,10 @@ class EmptyShelfDesignator(Designator):
                     rospy.logerr("Spacing of empty spot designator is too large!!!")
                     continue
 
-                frame_stamped = kdlFrameStampedFromXYZRPY()
-                frame_stamped.header.stamp = rospy.Time.now(x=box.max_corner.x() - self._edge_distance,
-                                                y=y,
-                                                z=box.min_corner.z() - 0.04,  # 0.04 is the usual offset)
-                                                frame_id=e.id)
+                frame_stamped = kdlFrameStampedFromXYZRPY(  x=box.max_corner.x() - self._edge_distance,
+                                                            y=y,
+                                                            z=box.min_corner.z() - 0.04,  # 0.04 is the usual offset)
+                                                            frame_id=e.id)
 
                 # e.convex_hull = []
                 # e.convex_hull.append(gm.Point(box['min']['x'], box['min']['y'], box['min']['z']))  # 1

--- a/challenge_manipulation/src/empty_shelf_designator.py
+++ b/challenge_manipulation/src/empty_shelf_designator.py
@@ -6,6 +6,7 @@ from robot_smach_states.util.designators import Designator
 import geometry_msgs.msg as gm
 from visualization_msgs.msg import MarkerArray, Marker
 import robot_skills.util.msg_constructors as msg_constructors
+from robot_skills.util.kdl_conversions import poseMsgToKdlFrame
 import PyKDL as kdl
 import copy
 
@@ -31,7 +32,7 @@ class EmptyShelfDesignator(Designator):
         :param name: name for introspection purposes
         :param area: (optional) area where the item should be placed
         """
-        super(EmptyShelfDesignator, self).__init__(resolve_type=gm.PoseStamped, name=name)
+        super(EmptyShelfDesignator, self).__init__(resolve_type=(kdl.Frame, str), name=name)
         self.robot = robot
 
         if area is None:
@@ -81,7 +82,7 @@ class EmptyShelfDesignator(Designator):
             ret = points_of_interest[self._count]
             self._count += 1
             rospy.loginfo("Place pose at: {0}".format(ret))
-            return ret
+            return poseMsgToKdlFrame(ret.pose), "/map"
 
 
     def create_marker(self, x, y, z, frame_id="/map"):

--- a/challenge_manipulation/src/manipulation.py
+++ b/challenge_manipulation/src/manipulation.py
@@ -421,9 +421,9 @@ class ManipRecogSingleItem(smach.StateMachine):
             :param entity:
             :return:
             """
-            if not entity.has_pose:
+            if not entity._pose:
                 return False
-            return MIN_GRASP_HEIGHT < entity.pose.position.z < MAX_GRASP_HEIGHT
+            return MIN_GRASP_HEIGHT < entity._pose.p.z() < MAX_GRASP_HEIGHT
 
         # select the entity closest in x direction to the robot in base_link frame
         def weight_function(entity):

--- a/challenge_manipulation/src/manipulation.py
+++ b/challenge_manipulation/src/manipulation.py
@@ -221,7 +221,7 @@ class FitEntity(smach.State):
         req.entity_type = self._entity_str  # 1280 1024
         req.px = 0.5
         req.py = 0.5
-        # result = self._srv(req)
+        result = self._srv(req)
 
         # Cancel the head goal and return
         self._robot.head.cancel_goal()

--- a/challenge_manipulation/src/manipulation.py
+++ b/challenge_manipulation/src/manipulation.py
@@ -365,6 +365,7 @@ class RemoveSegmentedEntities(smach.State):
 
         for e in entities:
             if not e.is_a("furniture") and e.id != '_root':
+                # import ipdb; ipdb.set_trace()
                 self.robot.ed.remove_entity(e.id)
 
         return "done"

--- a/challenge_manipulation/src/manipulation.py
+++ b/challenge_manipulation/src/manipulation.py
@@ -220,11 +220,11 @@ class FitEntity(smach.State):
         req.entity_type = self._entity_str  # 1280 1024
         req.px = 0.5
         req.py = 0.5
-        result = self._srv(req)
+        # result = self._srv(req)
 
         # Cancel the head goal and return
         self._robot.head.cancel_goal()
-        if result.error_msg:
+        if False: # result.error_msg:
             rospy.logerr("Fit entity: {0}".format(result))
             return 'failed'
         else:

--- a/challenge_manipulation/src/manipulation.py
+++ b/challenge_manipulation/src/manipulation.py
@@ -33,6 +33,7 @@ from robot_smach_states.util.startup import startup
 from robot_smach_states import Grab
 from robot_smach_states import Place
 from robot_smach_states.util.geometry_helpers import *
+from robot_skills.util.kdl_conversions import kdlVectorStampedFromPointStampedMsg
 
 # Robot Skills
 from robot_skills.util.entity import Entity
@@ -279,7 +280,7 @@ class InspectShelves(smach.State):
             # cp = shelf_entity.pose.position
 
             ''' Look at target '''
-            self.robot.head.look_at_point(ps)
+            self.robot.head.look_at_point(kdlVectorStampedFromPointStampedMsg(ps))
 
             ''' Move spindle
                 Implemented only for AMIGO (hence the hardcoding)

--- a/challenge_open/src/find_person.py
+++ b/challenge_open/src/find_person.py
@@ -115,7 +115,7 @@ class PersonDesignator(ds.Designator):
             # We just pick the person closest to the robot
             bp = self._robot.base.get_location()
             possible_humans = sorted(possible_humans,
-                                     key=lambda ph: ph.distance_to_2d(bp._pose.p))
+                                     key=lambda ph: ph.distance_to_2d(bp.p))
             return possible_humans[0]
 
 

--- a/challenge_open/src/find_person.py
+++ b/challenge_open/src/find_person.py
@@ -107,7 +107,7 @@ class PersonDesignator(ds.Designator):
 
             # Sort according to distance to center pose
             persons_in_room = sorted(persons_in_room,
-                                     key=lambda ph: ph.distance_to_2d(room_entity.pose.p))
+                                     key=lambda ph: ph.distance_to_2d(room_entity._pose.p))
 
             # Return the best one
             return persons_in_room[0]
@@ -115,7 +115,7 @@ class PersonDesignator(ds.Designator):
             # We just pick the person closest to the robot
             bp = self._robot.base.get_location()
             possible_humans = sorted(possible_humans,
-                                     key=lambda ph: ph.distance_to_2d(bp.pose.p))
+                                     key=lambda ph: ph.distance_to_2d(bp._pose.p))
             return possible_humans[0]
 
 

--- a/challenge_person_recognition/src/person_recognition_states/detect.py
+++ b/challenge_person_recognition/src/person_recognition_states/detect.py
@@ -1,4 +1,5 @@
 import robot_skills.util.msg_constructors as msgs
+from robot_skills.util.kdl_conversions import VectorStamped
 import time
 import smach
 import robot_smach_states as states
@@ -29,7 +30,7 @@ class RecognizePersons(smach.State):
 
     def _get_detections(self, external_api_request):
         z = 1.5
-        self.robot.head.look_at_point(msgs.PointStamped(100, 0, z, self.robot.robot_name + "/base_link"))
+        self.robot.head.look_at_point(VectorStamped(100, 0, z, self.robot.robot_name + "/base_link"))
         self.robot.head.wait_for_motion_done()
         time.sleep(1)
 
@@ -55,7 +56,7 @@ class RecognizePersons(smach.State):
 
     def _recognize(self):
         z = 1.5
-        self.robot.head.look_at_point(msgs.PointStamped(100, 0, z, self.robot.robot_name + "/base_link"))
+        self.robot.head.look_at_point(VectorStamped(100, 0, z, self.robot.robot_name + "/base_link"))
         self.robot.speech.speak("I am looking for my operator", block=False)
 
         # 1) Check how many people in the crowd

--- a/challenge_restaurant/package.xml
+++ b/challenge_restaurant/package.xml
@@ -18,5 +18,6 @@
   <run_depend>rospy</run_depend>
   <run_depend>python-markdown</run_depend>
   <run_depend>python-xhtml2pdf</run_depend>
+  <run_depend>python-numpy</run_depend>
 
 </package>

--- a/challenge_restaurant/src/automatic_side_detection.py
+++ b/challenge_restaurant/src/automatic_side_detection.py
@@ -9,7 +9,7 @@ from robot_smach_states.util.startup import startup
 from geometry_msgs.msg import PointStamped
 import robot_smach_states as states
 from robot_skills.util import transformations, msg_constructors
-from robot_skills.util.kdl_conversions import FrameStamped
+from robot_skills.util.kdl_conversions import FrameStamped, VectorStamped
 
 from robocup_knowledge import load_knowledge
 knowledge = load_knowledge("challenge_restaurant")
@@ -60,19 +60,15 @@ class AutomaticSideDetection(smach.State):
         self._min_area = min_area
 
     def _get_head_goal(self, spec):
-        goal = PointStamped()
-        goal.header.stamp = rospy.Time.now()
-        goal.header.frame_id = "/"+self._robot.robot_name+"/base_link"
-        goal.point.x = spec["x"]
-        goal.point.y = spec["y"]
-        return goal
+        vs = VectorStamped(spec["x"], spec["y"], z=0, frame_id="/"+self._robot.robot_name+"/base_link")
+        return vs
 
     def _inspect_sides(self):
         for side, spec in self._sides.iteritems():
             # Look at the side
             rospy.loginfo("looking at side %s" % side)
-            goal = self._get_head_goal(spec)
-            self._robot.head.look_at_point(goal)
+            vs = self._get_head_goal(spec)
+            self._robot.head.look_at_point(vs)
             self._robot.head.wait_for_motion_done()
             rospy.sleep(0.2)
 

--- a/challenge_restaurant/src/automatic_side_detection.py
+++ b/challenge_restaurant/src/automatic_side_detection.py
@@ -9,6 +9,7 @@ from robot_smach_states.util.startup import startup
 from geometry_msgs.msg import PointStamped
 import robot_smach_states as states
 from robot_skills.util import transformations, msg_constructors
+from robot_skills.util.kdl_conversions import FrameStamped
 
 from robocup_knowledge import load_knowledge
 knowledge = load_knowledge("challenge_restaurant")
@@ -219,7 +220,7 @@ class StoreWaypoint(smach.State):
         rospy.set_param("/restaurant_locations/{name}".format(name=location), loc_dict)
 
         visualize_location(base_pose, location)
-        self._robot.ed.update_entity(id=location, kdlFrame=base_pose, type="waypoint")
+        self._robot.ed.update_entity(id=location, kdlFrameStamped=FrameStamped(base_pose, "/map"), type="waypoint")
 
         return "done"
 

--- a/challenge_restaurant/src/automatic_side_detection.py
+++ b/challenge_restaurant/src/automatic_side_detection.py
@@ -219,7 +219,7 @@ class StoreWaypoint(smach.State):
         rospy.set_param("/restaurant_locations/{name}".format(name=location), loc_dict)
 
         visualize_location(base_pose, location)
-        self._robot.ed.update_entity(id=location, posestamped=base_pose, type="waypoint")
+        self._robot.ed.update_entity(id=location, kdlFrame=base_pose, type="waypoint")
 
         return "done"
 

--- a/challenge_restaurant/src/automatic_side_detection.py
+++ b/challenge_restaurant/src/automatic_side_detection.py
@@ -93,8 +93,8 @@ class AutomaticSideDetection(smach.State):
             self._sides[side]["score"]["area_sum"] = sum([ self._score_area(e) for e in self._sides[side]["entities"] ])
             self._sides[side]["score"]["min_distance"] = self._score_closest_point(base_position, self._sides[side]["entities"])
 
-            goal.point.z = 0.8
-            self._robot.head.look_at_point(goal)
+            vs.vector.z(0.8)
+            self._robot.head.look_at_point(vs)
             self._robot.head.wait_for_motion_done()
             rospy.sleep(0.2)
 

--- a/challenge_restaurant/src/automatic_side_detection.py
+++ b/challenge_restaurant/src/automatic_side_detection.py
@@ -75,7 +75,7 @@ class AutomaticSideDetection(smach.State):
             self._robot.head.wait_for_motion_done()
             rospy.sleep(0.2)
 
-            base_position = self._robot.base.get_location().pose.position
+            base_position = self._robot.base.get_location().p
 
             # Update kinect
             try:
@@ -101,28 +101,28 @@ class AutomaticSideDetection(smach.State):
             self._robot.head.wait_for_motion_done()
             rospy.sleep(0.2)
 
-			rospy.logerr("ed.detect _persons() method disappeared! This was only calling the face recognition module and we are using a new one now!")
-			rospy.logerr("I will return an empty detection list!")
-			persons = []
+            rospy.logerr("ed.detect _persons() method disappeared! This was only calling the face recognition module and we are using a new one now!")
+            rospy.logerr("I will return an empty detection list!")
+            persons = []
             self._sides[side]["score"]["face_found"] = False
             if persons:
                 for person in persons:
                     p = person.pose.pose.position
-                    if math.hypot(p.x - base_position.x, p.y - base_position.y) < self._max_radius:
+                    if math.hypot(p.x - base_position.x(), p.y - base_position.y()) < self._max_radius:
                         self._sides[side]["score"]["face_found"] = True
 
             if self._sides[side]["score"]["face_found"]:
                 self._robot.speech.speak("hi there")
 
     def _subset_selection(self, base_position, e):
-        distance = math.hypot(e.pose.position.x - base_position.x, e.pose.position.y - base_position.y)
+        distance = e.distance_to_2d(base_position)
         return distance < self._max_radius
 
     def _score_area(self, e):
         return _get_area(e.convex_hull)
 
     def _score_closest_point(self, base_position, entities):
-        distances = [ math.hypot(e.pose.position.x - base_position.x, e.pose.position.y - base_position.y) for e in entities ]
+        distances = [ e.distance_to_2d(base_position) for e in entities ]
         if distances:
             min_distance = min(distances)
         else:

--- a/challenge_restaurant/src/automatic_side_detection.py
+++ b/challenge_restaurant/src/automatic_side_detection.py
@@ -210,14 +210,12 @@ class StoreWaypoint(smach.State):
         self._robot.head.cancel_goal()
 
         if side == "left":
-            base_pose.pose.orientation = transformations.euler_z_to_quaternion(
-                transformations.euler_z_from_quaternion(base_pose.pose.orientation) + math.pi / 2)
+            base_pose.M.DoRotZ(math.pi / 2)
         elif side == "right":
-            base_pose.pose.orientation = transformations.euler_z_to_quaternion(
-                transformations.euler_z_from_quaternion(base_pose.pose.orientation) - math.pi / 2)
+            base_pose.M.DoRotZ(-math.pi / 2)
 
         # Add to param server
-        loc_dict = {'x':base_pose.pose.position.x, 'y':base_pose.pose.position.y, 'phi':transformations.euler_z_from_quaternion(base_pose.pose.orientation)}
+        loc_dict = {'x':base_pose.p.x(), 'y':base_pose.p.y(), 'phi':base_pose.M.GetRPY()[2]}
         rospy.set_param("/restaurant_locations/{name}".format(name=location), loc_dict)
 
         visualize_location(base_pose, location)

--- a/challenge_restaurant/src/challenge_restaurant.py
+++ b/challenge_restaurant/src/challenge_restaurant.py
@@ -106,7 +106,7 @@ class StoreKitchen(smach.State):
         robot.base.local_planner.cancelCurrentPlan()
 
     def execute(self, userdata):
-        self._robot.ed.update_entity(id="kitchen", posestamped=self._robot.base.get_location(), type="waypoint")
+        self._robot.ed.update_entity(id="kitchen", kdlFrame=self._robot.base.get_location(), type="waypoint")
 
         return "done"
 
@@ -616,10 +616,10 @@ def setup_statemachine(robot):
 
 
 def test_delivery(robot):
-    from robot_skills.util.msg_constructors import PoseStamped
-    robot.ed.update_entity(id="one", posestamped=PoseStamped(x=1.0, y=0, frame_id="/map"), type="waypoint")
-    robot.ed.update_entity(id="two", posestamped=PoseStamped(x=-1.2, y=0.0, frame_id="/map"), type="waypoint")
-    robot.ed.update_entity(id="three", posestamped=PoseStamped(x=1.950, y=1.551, frame_id="/map"), type="waypoint")
+    from robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY
+    robot.ed.update_entity(id="one", kdlFrame=kdlFrameFromXYZRPY(x=1.0, y=0), type="waypoint")
+    robot.ed.update_entity(id="two", kdlFrame=kdlFrameFromXYZRPY(x=-1.2, y=0.0), type="waypoint")
+    robot.ed.update_entity(id="three", kdlFrame=kdlFrameFromXYZRPY(x=1.950, y=1.551), type="waypoint")
 
     global ORDERS
     ORDERS = {"beverage":{"name":"coke", "location":"one"}, "combo":{"name":"pringles and chocolate", "location":"two"}}

--- a/challenge_restaurant/src/challenge_restaurant.py
+++ b/challenge_restaurant/src/challenge_restaurant.py
@@ -125,9 +125,9 @@ class StoreBeverageSide(smach.State):
             result = self._robot.ears.recognize('<side>', {'side':['left','right']}, time_out = rospy.Duration(10)) # Wait 100 secs
 
         if result.result == "left":
-            base_pose.pose.orientation = transformations.euler_z_to_quaternion(transformations.euler_z_from_quaternion(base_pose.pose.orientation) + math.pi / 2)
+            base_pose.M.DoRotZ(math.pi / 2)
         elif result.result == "right":
-            base_pose.pose.orientation = transformations.euler_z_to_quaternion(transformations.euler_z_from_quaternion(base_pose.pose.orientation) - math.pi / 2)
+            base_pose.M.DoRotZ(-math.pi / 2)
         else:
             print "\n\n WHUT?? No left or right lol? \n\n"
             print result

--- a/challenge_restaurant/src/challenge_restaurant.py
+++ b/challenge_restaurant/src/challenge_restaurant.py
@@ -191,13 +191,11 @@ else:
                     self._robot.head.cancel_goal()
 
                     if side == "left":
-                        base_pose.pose.orientation = transformations.euler_z_to_quaternion(
-                            transformations.euler_z_from_quaternion(base_pose.pose.orientation) + math.pi / 2)
+                        base_pose.M.DoRotZ(math.pi / 2)
                     elif side == "right":
-                        base_pose.pose.orientation = transformations.euler_z_to_quaternion(
-                            transformations.euler_z_from_quaternion(base_pose.pose.orientation) - math.pi / 2)
+                        base_pose.M.DoRotZ(-math.pi / 2)
 
-                    loc_dict = {'x':base_pose.pose.position.x, 'y':base_pose.pose.position.y, 'phi':transformations.euler_z_from_quaternion(base_pose.pose.orientation)}
+                    loc_dict = {'x':base_pose.p.x(), 'y':base_pose.p.y(), 'phi':base_pose.M.GetRPY()[2]}
                     rospy.set_param("/restaurant_locations/{name}".format(name=location), loc_dict)
                     visualize_location(base_pose, location)
                     self._robot.ed.update_entity(id=location, posestamped=base_pose, type="waypoint")

--- a/challenge_restaurant/src/challenge_restaurant.py
+++ b/challenge_restaurant/src/challenge_restaurant.py
@@ -26,6 +26,7 @@ from robot_smach_states.util.startup import startup
 
 from robot_smach_states.util.designators import VariableDesignator, EdEntityDesignator, EntityByIdDesignator, analyse_designators
 from robot_skills.util import transformations, msg_constructors
+from robot_skills.util.kdl_conversions import FrameStamped
 
 from robocup_knowledge import load_knowledge
 common_knowledge = load_knowledge("common")
@@ -106,7 +107,7 @@ class StoreKitchen(smach.State):
         robot.base.local_planner.cancelCurrentPlan()
 
     def execute(self, userdata):
-        self._robot.ed.update_entity(id="kitchen", kdlFrame=self._robot.base.get_location(), type="waypoint")
+        self._robot.ed.update_entity(id="kitchen", kdlFrameStamped=FrameStamped(self._robot.base.get_location(), "/map"), type="waypoint")
 
         return "done"
 
@@ -133,7 +134,7 @@ class StoreBeverageSide(smach.State):
             print result
             print "\n"
 
-        self._robot.ed.update_entity(id="beverages", posestamped=base_pose, type="waypoint")
+        self._robot.ed.update_entity(id="beverages", kdlFrameStamped=FrameStamped(base_pose, "/map"), type="waypoint")
         return "done"
 
 def load_waypoints(robot, filename="/param/locations.yaml"):
@@ -148,7 +149,7 @@ def load_waypoints(robot, filename="/param/locations.yaml"):
             base_pose.pose.orientation = transformations.euler_z_to_quaternion(location['phi'])
 
             visualize_location(base_pose, tablename)
-            robot.ed.update_entity(id=tablename, posestamped=base_pose, type="waypoint")
+            robot.ed.update_entity(id=tablename, kdlFrameStamped=FrameStamped(base_pose, "/map"), type="waypoint")
 
 if "--custom" not in sys.argv:
     from automatic_side_detection import StoreWaypoint
@@ -198,7 +199,7 @@ else:
                     loc_dict = {'x':base_pose.p.x(), 'y':base_pose.p.y(), 'phi':base_pose.M.GetRPY()[2]}
                     rospy.set_param("/restaurant_locations/{name}".format(name=location), loc_dict)
                     visualize_location(base_pose, location)
-                    self._robot.ed.update_entity(id=location, posestamped=base_pose, type="waypoint")
+                    self._robot.ed.update_entity(id=location, kdlFrameStamped=FrameStamped(base_pose, "/map"), type="waypoint")
 
                     return "done"
 
@@ -616,10 +617,10 @@ def setup_statemachine(robot):
 
 
 def test_delivery(robot):
-    from robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY
-    robot.ed.update_entity(id="one", kdlFrame=kdlFrameFromXYZRPY(x=1.0, y=0), type="waypoint")
-    robot.ed.update_entity(id="two", kdlFrame=kdlFrameFromXYZRPY(x=-1.2, y=0.0), type="waypoint")
-    robot.ed.update_entity(id="three", kdlFrame=kdlFrameFromXYZRPY(x=1.950, y=1.551), type="waypoint")
+    from robot_skills.util.kdl_conversions import kdlFrameStampedFromXYZRPY
+    robot.ed.update_entity(id="one", kdlFrameStamped=kdlFrameStampedFromXYZRPY(x=1.0, y=0, frame_id="/map"), type="waypoint")
+    robot.ed.update_entity(id="two", kdlFrameStamped=kdlFrameStampedFromXYZRPY(x=-1.2, y=0.0, frame_id="/map"), type="waypoint")
+    robot.ed.update_entity(id="three", kdlFrameStamped=kdlFrameStampedFromXYZRPY(x=1.950, y=1.551, frame_id="/map"), type="waypoint")
 
     global ORDERS
     ORDERS = {"beverage":{"name":"coke", "location":"one"}, "combo":{"name":"pringles and chocolate", "location":"two"}}

--- a/challenge_speech_recognition/src/indirect_speech_recognition.py
+++ b/challenge_speech_recognition/src/indirect_speech_recognition.py
@@ -53,7 +53,7 @@ class Turn(smach.State):
         operator = None
         while not operator:
             operator = self.robot.ed.get_closest_entity(self, radius=1.9,
-                                                        center_point=self.robot.base.get_location().pose.position)
+                                                        center_point=self.robot.base.get_location().p)
             print operator
             if not operator:
                 vth = 0.5
@@ -65,9 +65,9 @@ class Turn(smach.State):
 
         # Turn towards the operator
         current = self.robot.base.get_location()
-        robot_th = tf.euler_z_from_quaternion(current.pose.orientation)
-        desired_th = math.atan2(operator.pose.position.y - current.pose.position.y,
-                                operator.pose.position.x - current.pose.position.x)
+        robot_th = current.M.GetRPY[2]  # Get the Yaw, rotation around Z
+        desired_th = math.atan2(operator._pose.p.y() - current.p.y(),
+                                operator._pose.p.x() - current.p.x())
 
         # Calculate params
         th = desired_th - robot_th

--- a/challenge_speech_recognition/src/indirect_speech_recognition.py
+++ b/challenge_speech_recognition/src/indirect_speech_recognition.py
@@ -65,7 +65,7 @@ class Turn(smach.State):
 
         # Turn towards the operator
         current = self.robot.base.get_location()
-        robot_th = current.M.GetRPY[2]  # Get the Yaw, rotation around Z
+        robot_th = current.M.GetRPY()[2]  # Get the Yaw, rotation around Z
         desired_th = math.atan2(operator._pose.p.y() - current.p.y(),
                                 operator._pose.p.x() - current.p.x())
 

--- a/challenge_test/src/test.py
+++ b/challenge_test/src/test.py
@@ -5,7 +5,6 @@
 # Date: October 2015
 ################################################
 
-import roslib;
 import rospy
 import sys
 import smach

--- a/challenge_test/src/test_random.py
+++ b/challenge_test/src/test_random.py
@@ -5,7 +5,6 @@
 # Date: October 2015
 ################################################
 
-import roslib;
 import rospy
 import sys
 import smach

--- a/robot_skills/src/robot_skills/arms.py
+++ b/robot_skills/src/robot_skills/arms.py
@@ -47,7 +47,7 @@ class Arm(object):
 
         # Get stuff from the parameter server
         offset = self.load_param('skills/arm/offset/' + self.side)
-        self.offset = kdl.Frame(kdl.Rotation.RPY(offset["roll"], offset["pith"], offset["yaw"]),
+        self.offset = kdl.Frame(kdl.Rotation.RPY(offset["roll"], offset["pitch"], offset["yaw"]),
                                 kdl.Vector(offset["x"], offset["y"], offset["z"]))
 
         self.marker_to_grippoint_offset = self.load_param('skills/arm/offset/marker_to_grippoint')

--- a/robot_skills/src/robot_skills/arms.py
+++ b/robot_skills/src/robot_skills/arms.py
@@ -171,6 +171,7 @@ class Arm(object):
         #Convert to baselink, which is needed because the offset is defined in the base_link frame
         frame_in_baselink = frameStamped.projectToFrame("/"+self.robot_name+"/base_link", self.tf_listener)
 
+        # TODO: Get rid of this custom message type
         # Create goal:
         grasp_precompute_goal = GraspPrecomputeGoal()
         grasp_precompute_goal.goal.header.frame_id = frame_in_baselink.frame_id

--- a/robot_skills/src/robot_skills/arms.py
+++ b/robot_skills/src/robot_skills/arms.py
@@ -2,6 +2,7 @@
 
 import rospy
 import std_msgs.msg
+import PyKDL as kdl
 import tf_server
 import visualization_msgs.msg
 from actionlib import SimpleActionClient, GoalStatus
@@ -45,7 +46,10 @@ class Arm(object):
         self._operational = True  # In simulation, there will be no hardware cb
 
         # Get stuff from the parameter server
-        self.offset = self.load_param('skills/arm/offset/' + self.side)
+        offset = self.load_param('skills/arm/offset/' + self.side)
+        self.offset = kdl.Frame(kdl.Rotation.RPY(offset["roll"], offset["pith"], offset["yaw"]),
+                                kdl.Vector(offset["x"], offset["y"], offset["z"]))
+
         self.marker_to_grippoint_offset = self.load_param('skills/arm/offset/marker_to_grippoint')
 
         self.joint_names = self.load_param('skills/arm/joint_names')
@@ -140,7 +144,7 @@ class Arm(object):
             else:
                 self._operational = True
 
-    def send_goal(self, px, py, pz, roll, pitch, yaw,
+    def send_goal(self, frame,
                   timeout=30,
                   pre_grasp=False,
                   frame_id='/base_link',
@@ -149,10 +153,13 @@ class Arm(object):
         """
         Send a arm to a goal:
 
-        Using a position px, py, pz and orientation roll, pitch, yaw. A time
+        Using a combination of position and orientation: a kdl.Frame. A time
         out time_out. pre_grasp means go to an offset that is normally needed
         for things such as grasping. You can also specify the frame_id which
-        defaults to base_link """
+        defaults to base_link
+
+        :param frame position and orientation to move the arm's end effector to
+        """
 
         # save the arguments for debugging later
         myargs = locals()
@@ -172,10 +179,11 @@ class Arm(object):
 
         grasp_precompute_goal.allowed_touch_objects = allowed_touch_objects
 
-        grasp_precompute_goal.goal.x = px
-        grasp_precompute_goal.goal.y = py
-        grasp_precompute_goal.goal.z = pz
+        grasp_precompute_goal.goal.x = frame.p.x()
+        grasp_precompute_goal.goal.y = frame.p.y()
+        grasp_precompute_goal.goal.z = frame.p.z()
 
+        roll, pitch, yaw = frame.M.GetRPY()
         grasp_precompute_goal.goal.roll  = roll
         grasp_precompute_goal.goal.pitch = pitch
         grasp_precompute_goal.goal.yaw   = yaw
@@ -183,14 +191,16 @@ class Arm(object):
         self._publish_marker(grasp_precompute_goal, [1, 0, 0], "grasp_point")
 
         # Add tunable parameters
+        offset_frame = frame * self.offset
 
-        grasp_precompute_goal.goal.x += self.offset['x']
-        grasp_precompute_goal.goal.y += self.offset['y']
-        grasp_precompute_goal.goal.z += self.offset['z']
+        grasp_precompute_goal.goal.x = offset_frame.p.x()
+        grasp_precompute_goal.goal.y = offset_frame.p.y()
+        grasp_precompute_goal.goal.z = offset_frame.p.z()
 
-        grasp_precompute_goal.goal.roll  += self.offset['roll']
-        grasp_precompute_goal.goal.pitch +=  self.offset['pitch']
-        grasp_precompute_goal.goal.yaw   += self.offset['yaw']
+        roll, pitch, yaw = frame.M.GetRPY()
+        grasp_precompute_goal.goal.roll  = roll
+        grasp_precompute_goal.goal.pitch = pitch
+        grasp_precompute_goal.goal.yaw   = yaw
 
         # rospy.loginfo("Arm goal: {0}".format(grasp_precompute_goal))
 

--- a/robot_skills/src/robot_skills/arms.py
+++ b/robot_skills/src/robot_skills/arms.py
@@ -165,7 +165,7 @@ class Arm(object):
 
         # If necessary, prefix frame_id
         if frameStamped.frame_id.find(self.robot_name) < 0:
-            frameStamped.frame_id = "/"+self.robot_name+frameStamped.frame_id
+            frameStamped.frame_id = "/"+self.robot_name+"/"+frameStamped.frame_id
             rospy.loginfo("Grasp precompute frame id = {0}".format(frameStamped.frame_id))
 
         #Convert to baselink, which is needed because the offset is defined in the base_link frame

--- a/robot_skills/src/robot_skills/base.py
+++ b/robot_skills/src/robot_skills/base.py
@@ -16,6 +16,7 @@ from cb_planner_msgs_srvs.srv import GetPlan, CheckPlan
 
 from .util import nav_analyzer
 from .util import transformations
+from robot_skills.util.kdl_conversions import poseMsgToKdlFrame
 
 
 ###########################################################################################################################
@@ -263,13 +264,13 @@ def get_location(robot_name, tf_listener):
         target_pose =  geometry_msgs.msg.PoseStamped(pose=geometry_msgs.msg.Pose(position=position, orientation=orientation))
         target_pose.header.frame_id = "/map"
         target_pose.header.stamp = time
-        return target_pose
+        return poseMsgToKdlFrame(target_pose.pose)
 
     except (tf.LookupException, tf.ConnectivityException):
         rospy.logerr("tf request failed!!!")
         target_pose =  geometry_msgs.msg.PoseStamped(pose=geometry_msgs.msg.Pose(position=position, orientation=orientation))
         target_pose.header.frame_id = "/map"
-        return target_pose
+        return poseMsgToKdlFrame(target_pose.pose)
 
 def computePathLength(path):
     distance = 0.0

--- a/robot_skills/src/robot_skills/base.py
+++ b/robot_skills/src/robot_skills/base.py
@@ -40,7 +40,6 @@ class LocalPlanner():
         goal.plan = plan
         goal.orientation_constraint = orientation_constraint
         self._orientation_constraint = orientation_constraint
-        #self.analyzer.count_plan(plan[0], plan[-1], 0.0, computePathLength(plan))
         self._action_client.send_goal(goal, done_cb = self.__doneCallback, feedback_cb = self.__feedbackCallback)
         self._goal_handle = self._action_client.gh
         rospy.loginfo("Goal handle = {0}".format(self._goal_handle))
@@ -120,9 +119,6 @@ class GlobalPlanner():
         plan_time = (end_time-start_time).to_sec()
 
         path_length = self.computePathLength(resp.plan)
-
-        #if path_length > 0:
-        #    self.analyzer.count_plan(resp.plan[0], resp.plan[-1], plan_time, path_length)
 
         return resp.plan
 

--- a/robot_skills/src/robot_skills/base.py
+++ b/robot_skills/src/robot_skills/base.py
@@ -219,6 +219,9 @@ class Base(object):
 
         #rospy.loginfo("initalpose = {0}".format(initial_pose))
 
+        # We have to do this twice for some reason, somewhere in ed_localization
+        self._initial_pose_publisher.publish(initial_pose)
+        rospy.sleep(0.5)
         self._initial_pose_publisher.publish(initial_pose)
 
         return True

--- a/robot_skills/src/robot_skills/head.py
+++ b/robot_skills/src/robot_skills/head.py
@@ -73,6 +73,7 @@ class Head():
     # -- Functionality --
 
     def look_at_point(self, vector_stamped, end_time=0, pan_vel=1.0, tilt_vel=1.0, timeout=0):
+        assert isinstance(vector_stamped, VectorStamped)
         point_stamped = kdlVectorStampedToPointStamped(vector_stamped)
         self._setHeadReferenceGoal(0, pan_vel, tilt_vel, end_time, point_stamped, timeout=timeout)
 

--- a/robot_skills/src/robot_skills/head.py
+++ b/robot_skills/src/robot_skills/head.py
@@ -5,7 +5,7 @@ from geometry_msgs.msg import PointStamped
 from head_ref.msg import HeadReferenceAction, HeadReferenceGoal
 
 from .util import msg_constructors as msgs
-from .util.kdl_conversions import kdlVectorStampedToPointStamped
+from .util.kdl_conversions import kdlVectorStampedToPointStamped, VectorStamped
 
 
 class Head():
@@ -24,12 +24,7 @@ class Head():
         """
         Reset head position
         """
-        reset_goal = PointStamped()
-        reset_goal.header.stamp = rospy.Time.now()
-        reset_goal.header.frame_id = "/"+self._robot_name+"/base_link"
-        reset_goal.point.x = 10
-        reset_goal.point.y = 0.0
-        reset_goal.point.z = 0.0
+        reset_goal = VectorStamped(x=10, frame_id="/"+self._robot_name+"/base_link")
 
         return self.look_at_point(reset_goal, timeout=timeout)
 
@@ -47,12 +42,7 @@ class Head():
             return False
 
     def look_at_ground_in_front_of_robot(self, distance=2):
-        goal = PointStamped()
-        goal.header.stamp = rospy.Time.now()
-        goal.header.frame_id = "/"+self._robot_name+"/base_link"
-        goal.point.x = distance
-        goal.point.y = 0.0
-        goal.point.z = 0.0
+        goal = VectorStamped(x=distance, frame_id="/"+self._robot_name+"/base_link")
 
         return self.look_at_point(goal)
 
@@ -60,12 +50,7 @@ class Head():
         """
         Gives a target at z = 1.0 at 1 m in front of the robot
         """
-        goal = PointStamped()
-        goal.header.stamp = rospy.Time.now()
-        goal.header.frame_id = "/"+self._robot_name+"/base_link"
-        goal.point.x = 1.0
-        goal.point.y = 0.0
-        goal.point.z = 0.5
+        goal = VectorStamped(1, 0, 0.5, frame_id="/"+self._robot_name+"/base_link")
 
         return self.look_at_point(goal)
 
@@ -73,12 +58,7 @@ class Head():
         """
         Gives a target at z = 1.0 at 1 m in front of the robot
         """
-        goal = PointStamped()
-        goal.header.stamp = rospy.Time.now()
-        goal.header.frame_id = "/"+self._robot_name+"/base_link"
-        goal.point.x = 0.2
-        goal.point.y = 0.0
-        goal.point.z = 4.5
+        goal = VectorStamped(0.2, 0.0, 4.5, frame_id="/"+self._robot_name+"/base_link")
 
         return self.look_at_point(goal)
 
@@ -86,12 +66,7 @@ class Head():
         """
         Gives a target at z = 1.75 at 1 m in front of the robot
         """
-        goal = PointStamped()
-        goal.header.stamp = rospy.Time.now()
-        goal.header.frame_id = "/"+self._robot_name+"/base_link"
-        goal.point.x = 1.0
-        goal.point.y = 0.0
-        goal.point.z = 1.6
+        goal = VectorStamped(1.0, 0.0, 1.6, frame_id="/" + self._robot_name + "/base_link")
 
         return self.look_at_point(goal)
 

--- a/robot_skills/src/robot_skills/head.py
+++ b/robot_skills/src/robot_skills/head.py
@@ -5,6 +5,7 @@ from geometry_msgs.msg import PointStamped
 from head_ref.msg import HeadReferenceAction, HeadReferenceGoal
 
 from .util import msg_constructors as msgs
+from .util.kdl_conversions import kdlVectorStampedToPointStamped
 
 
 class Head():
@@ -96,7 +97,8 @@ class Head():
 
     # -- Functionality --
 
-    def look_at_point(self, point_stamped, end_time=0, pan_vel=1.0, tilt_vel=1.0, timeout=0):
+    def look_at_point(self, vector_stamped, end_time=0, pan_vel=1.0, tilt_vel=1.0, timeout=0):
+        point_stamped = kdlVectorStampedToPointStamped(vector_stamped)
         self._setHeadReferenceGoal(0, pan_vel, tilt_vel, end_time, point_stamped, timeout=timeout)
 
     def cancel_goal(self):

--- a/robot_skills/src/robot_skills/mockbot.py
+++ b/robot_skills/src/robot_skills/mockbot.py
@@ -14,6 +14,7 @@ from ed_sensor_integration.srv import UpdateResponse
 
 import arms
 from robot_skills import robot
+from robot_skills.util.kdl_conversions import VectorStamped
 from robot_skills.classification_result import ClassificationResult
 import robot_skills.util.msg_constructors as msgs
 
@@ -294,7 +295,7 @@ if __name__ == "__main__":
     left_open = lambda: mockbot.leftArm.send_gripper_goal_open()
     speak = lambda sentence: mockbot.speech.speak(sentence, block=False)
     praat = lambda sentence: mockbot.speech.speak(sentence, language='nl', block=False)
-    look_at_point = lambda x, y, z: mockbot.head.look_at_point(msgs.PointStamped(x, y, z, frame_id="/mockbot/base_link"))
+    look_at_point = lambda x, y, z: mockbot.head.look_at_point(VectorStamped(x, y, z, frame_id="/mockbot/base_link"))
 
     mapgo = mockbot.base.go
 

--- a/robot_skills/src/robot_skills/util/entity.py
+++ b/robot_skills/src/robot_skills/util/entity.py
@@ -2,6 +2,7 @@
 import yaml
 
 # ROS
+import rospy
 import PyKDL as kdl
 
 from robot_skills.util.kdl_conversions import poseMsgToKdlFrame, kdlFrameToPoseMsg
@@ -112,6 +113,7 @@ def from_entity_info(e):
 
     # The data is a string but can be parsed as yaml, which then represent is a much more usable data structure
     volumes = volumes_from_entity_info_data(yaml.load(e.data))
+    rospy.logdebug("Entity(id={id}) has volumes {vols} ".format(id=identifier, vols=volumes.keys()))
 
     super_types = e.types
 

--- a/robot_skills/src/robot_skills/util/entity.py
+++ b/robot_skills/src/robot_skills/util/entity.py
@@ -4,7 +4,7 @@ import yaml
 # ROS
 import PyKDL as kdl
 
-from robot_skills.util.kdl_conversions import pose_msg_to_kdl_frame, kdl_frame_to_pose_msg
+from robot_skills.util.kdl_conversions import poseMsgToKdlFrame, kdlFrameToPoseMsg
 from robot_skills.util.volume import volumes_from_entity_info_data
 from robot_skills.util.shape import shape_from_entity_info
 
@@ -88,12 +88,12 @@ class Entity(object):
     @property
     def pose(self):
         """ Returns the pose (at this point, as a geometry_msgs.Pose, in the future as a kdl frame """
-        return kdl_frame_to_pose_msg(self._pose)
+        return kdlFrameToPoseMsg(self._pose)
 
     @pose.setter
     def pose(self, pose):
         """ Setter """
-        self._pose = pose_msg_to_kdl_frame(pose)
+        self._pose = poseMsgToKdlFrame(pose)
 
 
 def from_entity_info(e):
@@ -105,7 +105,7 @@ def from_entity_info(e):
     identifier = e.id
     object_type = e.type
     frame_id = "/map"  # ED has all poses in map
-    pose = pose_msg_to_kdl_frame(e.pose)
+    pose = poseMsgToKdlFrame(e.pose)
     shape = shape_from_entity_info(e)
 
     last_update_time = e.last_update_time.to_sec()

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -28,10 +28,22 @@ class FrameStamped(object):
         transformed_pose = tf_listener.transformPose(frame_id, kdlFrameStampedToPoseStampedMsg(self))
         return kdlFrameStampedFromPoseStampedMsg(transformed_pose)
 
+    def extractVectorStamped(self):
+        """Extract only the position of this FrameStamped, without the orientation but with the frame_id metadata
+        :returns VectorStamped
+        >>> fs = FrameStamped(kdl.Frame(kdl.Rotation.Quaternion(1, 0, 0, 0), kdl.Vector(1, 2, 3)), "/map")
+        >>> fs.extractVectorStamped()
+        [           1,           2,           3] @ /map
+        """
+        return VectorStamped(frame_id=self.frame_id, vector=self.frame.p)
+
 
 class VectorStamped(object):
-    def __init__(self, x=0, y=0, z=0, frame_id="/map"):
-        self.vector = kdl.Vector(x, y, z)
+    def __init__(self, x=0, y=0, z=0, frame_id="/map", vector=None):
+        if vector:
+            self.vector = vector
+        else:
+            self.vector = kdl.Vector(x, y, z)
         self.frame_id = frame_id
 
     def __repr__(self):

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -147,13 +147,13 @@ def kdlFrameStampedToPoseStampedMsg(frame_stamped):
 def kdlFrameFromXYZRPY(x=0, y=0, z=0, roll=0, pitch=0, yaw=0):
     """
     Create a PyKDL.Frame from raw scalars
-    :param x:
-    :param y:
-    :param z:
-    :param roll:
-    :param pitch:
-    :param yaw:
-    :return:
+    :param x: The X value of the position
+    :param y: The Y value of the position
+    :param z: The Z value of the position
+    :param roll: The roll of the orientation
+    :param pitch: The pitch of the orientation
+    :param yaw: The yaw of the orientation
+    :return: the given position and orientation represented as a kdl.Frame
     :rtype: PyKDL.Frame
     """
     return kdl.Frame(kdl.Rotation.RPY(roll, pitch, yaw), kdl.Vector(x,y,z))
@@ -168,15 +168,15 @@ def kdlFrameStampedFromPoseStampedMsg(pose_stamped):
 
 def kdlFrameStampedFromXYZRPY(x=0, y=0, z=0, roll=0, pitch=0, yaw=0, frame_id="/map"):
     """
-    Create a FrameStamped from raw scalars and a frame_id
-    :param x:
-    :param y:
-    :param z:
-    :param roll:
-    :param pitch:
-    :param yaw:
-    :param frame_id:
-    :return:
+    Create a FrameStamped from raw scalars
+    :param x: The X value of the position
+    :param y: The Y value of the position
+    :param z: The Z value of the position
+    :param roll: The roll of the orientation
+    :param pitch: The pitch of the orientation
+    :param yaw: The yaw of the orientation
+    :param frame_id: the frame_id in which the frame is defined
+    :return: the given position and orientation represented as a kdl.Frame
     :rtype: FrameStamped
     """
     return FrameStamped(frame=kdl.Frame(kdl.Rotation.RPY(roll, pitch, yaw), kdl.Vector(x,y,z)),

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -106,6 +106,20 @@ def kdlFrameToPoseMsg(frame):
     pose.orientation = kdlRotationToQuaternionMsg(frame.M)
     return pose
 
+def kdlFrameFromXYZRPY(x, y, z, roll, pitch, yaw):
+    """
+    Create a PyKDL.Frame from raw scalars
+    :param x:
+    :param y:
+    :param z:
+    :param roll:
+    :param pitch:
+    :param yaw:
+    :return:
+    :rtype: PyKDL.Frame
+    """
+    return kdl.Frame(kdl.Rotation.RPY(roll, pitch, yaw), kdl.Vector(x,y,z))
+
 if __name__ == "__main__":
     import doctest
     doctest.testmod()

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -106,7 +106,7 @@ def kdlFrameToPoseMsg(frame):
     pose.orientation = kdlRotationToQuaternionMsg(frame.M)
     return pose
 
-def kdlFrameFromXYZRPY(x, y, z, roll, pitch, yaw):
+def kdlFrameFromXYZRPY(x=0, y=0, z=0, roll=0, pitch=0, yaw=0):
     """
     Create a PyKDL.Frame from raw scalars
     :param x:

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -21,9 +21,6 @@ class FrameStamped(object):
         return "{frame} @ {fid}".format(frame=self.frame, fid=self.frame_id)
 
     def projectToFrame(self, frame_id, tf_listener):
-        tf_listener = tf.TransformListener()  # TODO: This is a fix for a problem in tf_server.tf_client @ 1503bd4
-        time.sleep(1)
-
         tf_listener.waitForTransform(self.frame_id, frame_id, time=rospy.Time.now(), timeout=rospy.Duration(1))
         transformed_pose = tf_listener.transformPose(frame_id, kdlFrameStampedToPoseStampedMsg(self))
         return kdlFrameStampedFromPoseStampedMsg(transformed_pose)
@@ -50,9 +47,6 @@ class VectorStamped(object):
         return "{vector} @ {fid}".format(vector=self.vector, fid=self.frame_id)
 
     def projectToFrame(self, frame_id, tf_listener):
-        tf_listener = tf.TransformListener()  # TODO: This is a fix for a problem in tf_server.tf_client @ 1503bd4
-        time.sleep(1)
-
         tf_listener.waitForTransform(self.frame_id, frame_id, time=rospy.Time.now(), timeout=rospy.Duration(1))
         transformed_point = tf_listener.transformPoint(frame_id, kdlVectorStampedToPointStamped(self))
         return kdlVectorStampedFromPointStampedMsg(transformed_point)

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -28,10 +28,14 @@ class FrameStamped(object):
         transformed_pose = tf_listener.transformPose(frame_id, kdlFrameStampedToPoseStampedMsg(self))
         return kdlFrameStampedFromPoseStampedMsg(transformed_pose)
 
+
 class VectorStamped(object):
-    def __init__(self, x, y, z, frame_id="/map"):
+    def __init__(self, x=0, y=0, z=0, frame_id="/map"):
         self.vector = kdl.Vector(x, y, z)
         self.frame_id = frame_id
+
+    def __repr__(self):
+        return "{vector} @ {fid}".format(vector=self.vector, fid=self.frame_id)
 
     def projectToFrame(self, frame_id, tf_listener):
         tf_listener = tf.TransformListener()  # TODO: This is a fix for a problem in tf_server.tf_client @ 1503bd4
@@ -40,6 +44,13 @@ class VectorStamped(object):
         tf_listener.waitForTransform(self.frame_id, frame_id, time=rospy.Time.now(), timeout=rospy.Duration(1))
         transformed_point = tf_listener.transformPoint(frame_id, kdlVectorStampedToPointStamped(self))
         return kdlVectorStampedFromPointStampedMsg(transformed_point)
+
+    def __eq__(self, other):
+        if isinstance(other, VectorStamped):
+            return self.vector == other.vector and \
+                   self.frame_id == other.frame_id
+        else:
+            return False
 
 
 def pointMsgToKdlVector(point):

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -2,6 +2,17 @@ import PyKDL as kdl
 
 import geometry_msgs.msg as gm
 
+
+class FrameStamped(object):
+    """Kdl alternative for a geometry_msgs.PoseStamped.
+    This class consists of a kdl.Frame and the frame_id w.r.t which the Frame is defined"""
+
+    def __init__(self, frame, frame_id):
+        assert isinstance(frame, kdl.Frame)
+        self.frame = frame
+        self.frame_id = frame_id
+
+
 def pointMsgToKdlVector(point):
     """
     Convert a ROS geometry_msgs.msg.Point message to a PyKDL.Vector object
@@ -119,6 +130,30 @@ def kdlFrameFromXYZRPY(x=0, y=0, z=0, roll=0, pitch=0, yaw=0):
     :rtype: PyKDL.Frame
     """
     return kdl.Frame(kdl.Rotation.RPY(roll, pitch, yaw), kdl.Vector(x,y,z))
+
+def kdlFrameStampedFromPoseStampedMsg(pose_stamped):
+    """Convert a PoseStamped to FrameStamped
+    :param pose_stamped the PoseStamped to be converted
+    :returns FrameStamped"""
+    assert isinstance(pose_stamped, gm.PoseStamped)
+    return FrameStamped(frame=poseMsgToKdlFrame(pose_stamped.pose),
+                        frame_id=pose_stamped.header.frame_id)
+
+def kdlFrameStampedFromXYZRPY(x=0, y=0, z=0, roll=0, pitch=0, yaw=0, frame_id="/map"):
+    """
+    Create a FrameStamped from raw scalars and a frame_id
+    :param x:
+    :param y:
+    :param z:
+    :param roll:
+    :param pitch:
+    :param yaw:
+    :param frame_id:
+    :return:
+    :rtype: FrameStamped
+    """
+    return FrameStamped(frame=kdl.Frame(kdl.Rotation.RPY(roll, pitch, yaw), kdl.Vector(x,y,z)),
+                        frame_id=frame_id)
 
 if __name__ == "__main__":
     import doctest

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -15,6 +15,10 @@ class FrameStamped(object):
     def __repr__(self):
         return "{frame} @ {fid}".format(frame=self.frame, fid=self.frame_id)
 
+    def projectToFrame(self, frame_id, tf_listener):
+        transformed_pose = tf_listener.transformPose(frame_id, kdlFrameStampedToPoseStampedMsg(self))
+        return kdlFrameStampedFromPoseStampedMsg(transformed_pose)
+
 
 def pointMsgToKdlVector(point):
     """
@@ -85,7 +89,7 @@ def quaternionMsgToKdlRotation(quaternion):
 
 def poseMsgToKdlFrame(pose):
     """
-    Convert a geometry_msgs.msg.Pose message to a ROS PyKDL.Frame object
+    Convert a geometry_msgs.msg.Pose message to a PyKDL.Frame object
     :param pose: Pose to be converted
     :type pose: geometry_msgs.msg.Pose
     :rtype: PyKDL.Frame
@@ -119,6 +123,26 @@ def kdlFrameToPoseMsg(frame):
     pose.position = kdlVectorToPointMsg(frame.p)
     pose.orientation = kdlRotationToQuaternionMsg(frame.M)
     return pose
+
+def kdlFrameStampedToPoseStampedMsg(frame_stamped):
+    """
+    Convert a ROS PyKDL.Frame object to a geometry_msgs.msg.Pose message
+    :param frame: Frame to be converted
+    :type frame: PyKDL.Frame
+    :rtype: geometry_msgs.msg.Pose
+
+    >>> frame = kdl.Frame(kdl.Rotation.Quaternion(1, 0, 0, 0), kdl.Vector(1, 2, 3))
+    >>> pose = kdlFrameToPoseMsg(frame)
+    >>> (pose.position.x, pose.position.y, pose.position.z)
+    (1.0, 2.0, 3.0)
+    >>> (pose.orientation.x, pose.orientation.y, pose.orientation.z, pose.orientation.w)
+    (1.0, 0.0, 0.0, 0.0)
+    """
+    pose_stamped = gm.PoseStamped()
+    pose_stamped.header.frame_id = frame_stamped.frame_id
+    pose_stamped.pose.position = kdlVectorToPointMsg(frame_stamped.frame.p)
+    pose_stamped.pose.orientation = kdlRotationToQuaternionMsg(frame_stamped.frame.M)
+    return pose_stamped
 
 def kdlFrameFromXYZRPY(x=0, y=0, z=0, roll=0, pitch=0, yaw=0):
     """

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -232,7 +232,7 @@ def kdlVectorStampedFromPointStampedMsg(point_stamped):
     :param point_stamped the PointStamped to be converted
     :returns VectorStamped"""
     assert isinstance(point_stamped, gm.PointStamped)
-    return VectorStamped(point=pointMsgToKdlVector(point_stamped.point),
+    return VectorStamped(vector=pointMsgToKdlVector(point_stamped.point),
                          frame_id=point_stamped.header.frame_id)
 
 def kdlVectorStampedToPointStamped(vector_stamped):
@@ -241,9 +241,10 @@ def kdlVectorStampedToPointStamped(vector_stamped):
     :returns PointStamped"""
     ps = gm.PointStamped()
     ps.header.frame_id = vector_stamped.frame_id
-    ps.point = gm.Point(vector_stamped.vector.x,
-                        vector_stamped.vector.y,
-                        vector_stamped.vector.z)
+    ps.point = gm.Point(vector_stamped.vector.x(),
+                        vector_stamped.vector.y(),
+                        vector_stamped.vector.z())
+    return ps
 
 if __name__ == "__main__":
     import doctest

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -12,6 +12,9 @@ class FrameStamped(object):
         self.frame = frame
         self.frame_id = frame_id
 
+    def __repr__(self):
+        return "{frame} @ {fid}".format(frame=self.frame, fid=self.frame_id)
+
 
 def pointMsgToKdlVector(point):
     """

--- a/robot_skills/src/robot_skills/util/kdl_conversions.py
+++ b/robot_skills/src/robot_skills/util/kdl_conversions.py
@@ -1,4 +1,9 @@
+import rospy
 import PyKDL as kdl
+
+# Needed for UGLY hacks
+import tf
+import time
 
 import geometry_msgs.msg as gm
 
@@ -7,7 +12,7 @@ class FrameStamped(object):
     """Kdl alternative for a geometry_msgs.PoseStamped.
     This class consists of a kdl.Frame and the frame_id w.r.t which the Frame is defined"""
 
-    def __init__(self, frame, frame_id):
+    def __init__(self, frame, frame_id, stamp=None):
         assert isinstance(frame, kdl.Frame)
         self.frame = frame
         self.frame_id = frame_id
@@ -16,6 +21,10 @@ class FrameStamped(object):
         return "{frame} @ {fid}".format(frame=self.frame, fid=self.frame_id)
 
     def projectToFrame(self, frame_id, tf_listener):
+        tf_listener = tf.TransformListener()  # TODO: This is a fix for a problem in tf_server.tf_client @ 1503bd4
+        time.sleep(1)
+
+        tf_listener.waitForTransform(self.frame_id, frame_id, time=rospy.Time.now(), timeout=rospy.Duration(10))
         transformed_pose = tf_listener.transformPose(frame_id, kdlFrameStampedToPoseStampedMsg(self))
         return kdlFrameStampedFromPoseStampedMsg(transformed_pose)
 

--- a/robot_skills/src/robot_skills/util/nav_analyzer.py
+++ b/robot_skills/src/robot_skills/util/nav_analyzer.py
@@ -116,7 +116,7 @@ class NavAnalyzer:
 
         ''' Log startpose '''
         startposeitem = ET.SubElement(self.logitem, "startpose")
-        self.poseStampedToSubElement(startpose, startposeitem)
+        self.kdlFrameToSubElement(startpose, startposeitem)
 
         ''' Start bagging '''
         # The os.setsid() is passed in the argument preexec_fn so
@@ -142,7 +142,7 @@ class NavAnalyzer:
 
         ''' Log endpose '''
         endposeitem = ET.SubElement(self.logitem, "endpose")
-        self.poseStampedToSubElement(endpose, endposeitem)
+        self.kdlFrameToSubElement(endpose, endposeitem)
 
         ''' Make inactive '''
         self.active = False
@@ -253,6 +253,14 @@ class NavAnalyzer:
         #yitem.text = "{0}".format(y)
         #phiitem = ET.SubElement(element, "phi")
         #phiitem.text = "{0}".format(phi)
+
+    def kdlFrameToSubElement(self, kdlFrame, element):
+        x   = kdlFrame.p.x()
+        y   = kdlFrame.p.y()
+        phi = kdlFrame.M.GetRPY()[2]  # Get the yaw
+        element.set("x", "{0}".format(x))
+        element.set("y", "{0}".format(y))
+        element.set("phi", "{0}".format(phi))
 
     def getTimeStamp(self):
         stamp = datetime.datetime.now()

--- a/robot_skills/src/robot_skills/util/nav_analyzer.py
+++ b/robot_skills/src/robot_skills/util/nav_analyzer.py
@@ -198,24 +198,6 @@ class NavAnalyzer:
     def abort_measurement(self):
         self.active = False
 
-    def count_reset(self, pose):
-        self.nr_reset_costmap +=1
-        stamp    = self.getTimeStamp()
-        resetitem = ET.SubElement(self.resetitems, "reset")
-        resetitem.set("id", "{0}".format(self.nr_reset_costmap))
-        resetitem.set("stamp", stamp)
-        poseitem = ET.SubElement(resetitem, "pose")
-        self.poseStampedToSubElement(pose, poseitem)
-
-    def count_clear(self, pose):
-        self.nr_clear_costmap +=1
-        stamp    = self.getTimeStamp()
-        clearitem = ET.SubElement(self.clearitems, "clear")
-        clearitem.set("id", "{0}".format(self.nr_clear_costmap))
-        clearitem.set("stamp", stamp)
-        poseitem = ET.SubElement(clearitem, "pose")
-        self.poseStampedToSubElement(pose, poseitem)
-
     def odomCallback(self, odom_msg):
 
         current_position = odom_msg.pose.pose.position

--- a/robot_skills/src/robot_skills/util/nav_analyzer.py
+++ b/robot_skills/src/robot_skills/util/nav_analyzer.py
@@ -198,19 +198,6 @@ class NavAnalyzer:
     def abort_measurement(self):
         self.active = False
 
-    def count_plan(self, robot_pose, target_pose, plantime, distance):
-        self.nr_plan +=1
-        stamp    = self.getTimeStamp()
-        planitem = ET.SubElement(self.planitems, "plan")
-        planitem.set("id", "{0}".format(self.nr_plan))
-        planitem.set("stamp", stamp)
-        planitem.set("planning_time", "{0}".format(plantime))
-        planitem.set("planning_distance", "{0}".format(distance))
-        robotposeitem = ET.SubElement(planitem, "robot_pose")
-        self.poseStampedToSubElement(robot_pose, robotposeitem)
-        goalposeitem = ET.SubElement(planitem, "goal_pose")
-        self.poseStampedToSubElement(target_pose, goalposeitem)
-
     def count_reset(self, pose):
         self.nr_reset_costmap +=1
         stamp    = self.getTimeStamp()

--- a/robot_skills/src/robot_skills/util/shape.py
+++ b/robot_skills/src/robot_skills/util/shape.py
@@ -11,21 +11,49 @@ class Shape(object):
         return self._calc_convex_hull()
 
     def _calc_convex_hull(self):
-        raise NotImplementedError("_calc_convex_hull must be implemented by subclasses")
+        raise NotImplementedError("_calc_convex_hull must be implemented by subclasses. Class {cls} has no implementation".format(cls=self.__class__.__name__))
+
+    @property
+    def x_min(self):
+        return self._calc_x_min()
+
+    def _calc_x_min(self):
+        raise NotImplementedError("_calc_x_min must be implemented by subclasses. Class {cls} has no implementation".format(cls=self.__class__.__name__))
+
+    @property
+    def x_max(self):
+        return self._calc_x_max()
+
+    def _calc_x_max(self):
+        raise NotImplementedError("_calc_x_max must be implemented by subclasses. Class {cls} has no implementation".format(cls=self.__class__.__name__))
+
+    @property
+    def y_min(self):
+        return self._calc_y_min()
+
+    def _calc_y_min(self):
+        raise NotImplementedError("_calc_y_min must be implemented by subclasses. Class {cls} has no implementation".format(cls=self.__class__.__name__))
+
+    @property
+    def y_max(self):
+        return self._calc_y_max()
+
+    def _calc_y_max(self):
+        raise NotImplementedError("_calc_y_max must be implemented by subclasses. Class {cls} has no implementation".format(cls=self.__class__.__name__))
 
     @property
     def z_min(self):
         return self._calc_z_min()
 
     def _calc_z_min(self):
-        raise NotImplementedError("_calc_z_min must be implemented by subclasses")
+        raise NotImplementedError("_calc_z_min must be implemented by subclasses. Class {cls} has no implementation".format(cls=self.__class__.__name__))
 
     @property
     def z_max(self):
-        return self._calc_z_min()
+        return self._calc_z_max()
 
     def _calc_z_max(self):
-        raise NotImplementedError("_calc_z_min must be implemented by subclasses")
+        raise NotImplementedError("_calc_z_max must be implemented by subclasses. Class {cls} has no implementation".format(cls=self.__class__.__name__))
 
 
 class RightPrism(Shape):
@@ -46,6 +74,18 @@ class RightPrism(Shape):
         self._convex_hull = convex_hull
         self._z_min = z_min
         self._z_max = z_max
+
+    def _calc_x_max(self):
+        return max(ch.x() for ch in self._convex_hull)
+
+    def _calc_x_min(self):
+        return min(ch.x() for ch in self._convex_hull)
+
+    def _calc_y_max(self):
+        return max(ch.y() for ch in self._convex_hull)
+
+    def _calc_y_min(self):
+        return min(ch.y() for ch in self._convex_hull)
 
     def _calc_z_max(self):
         return self._z_max

--- a/robot_skills/src/robot_skills/util/shape.py
+++ b/robot_skills/src/robot_skills/util/shape.py
@@ -1,5 +1,5 @@
 # Robot skills
-from robot_skills.util.kdl_conversions import point_msg_to_kdl_vector
+from robot_skills.util.kdl_conversions import pointMsgToKdlVector
 
 
 class Shape(object):
@@ -69,6 +69,6 @@ def shape_from_entity_info(e):
     if not e.convex_hull:
         return Shape()
 
-    return RightPrism(convex_hull=[point_msg_to_kdl_vector(p) for p in e.convex_hull],
+    return RightPrism(convex_hull=[pointMsgToKdlVector(p) for p in e.convex_hull],
                       z_min=e.z_min,
                       z_max=e.z_max)

--- a/robot_skills/src/robot_skills/util/volume.py
+++ b/robot_skills/src/robot_skills/util/volume.py
@@ -65,6 +65,7 @@ class BoxVolume(Volume):
         convex_hull.append(kdl.Vector(self.max_corner.x(), self.min_corner.y(), self.min_corner.z()))  # 2
         convex_hull.append(kdl.Vector(self.max_corner.x(), self.max_corner.y(), self.min_corner.z()))  # 3
         convex_hull.append(kdl.Vector(self.min_corner.x(), self.max_corner.y(), self.min_corner.z()))  # 4
+        return convex_hull
 
 
 class OffsetVolume(Volume):

--- a/robot_skills/src/robot_skills/world_model_ed.py
+++ b/robot_skills/src/robot_skills/world_model_ed.py
@@ -157,7 +157,7 @@ class ED:
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def update_entity(self, id, type = None, kdlFrame = None, flags = None, add_flags = [], remove_flags = [], action = None):
+    def update_entity(self, id, type = None, kdlFrame = None, frame_id="/map", flags = None, add_flags = [], remove_flags = [], action = None):
         """
         Updates entity
         :param id: entity id
@@ -178,6 +178,9 @@ class ED:
         if kdlFrame:
             Z, Y, X = kdlFrame.M.GetEulerZYX()
             t = kdlFrame.p
+            if frame_id != "/map":
+                #  TODO: transform to /map
+                pass
             json_entity += ', "pose": { "x": %f, "y": %f, "z": %f, "X": %f, "Y": %f, "Z": %f }' % (t.x(), t.y(), t.z(), X, Y, Z)
 
         if flags or add_flags or remove_flags:

--- a/robot_skills/src/robot_skills/world_model_ed.py
+++ b/robot_skills/src/robot_skills/world_model_ed.py
@@ -176,12 +176,11 @@ class ED:
             json_entity += ', "action": "%s"' % action
 
         if kdlFrameStamped:
+            if kdlFrameStamped.frame_id != "/map":
+                kdlFrameStamped = kdlFrameStamped.projectToFrame("/map", self._tf_listener)
+
             Z, Y, X = kdlFrameStamped.frame.M.GetEulerZYX()
             t = kdlFrameStamped.frame.p
-            if kdlFrameStamped.frame_id != "/map":
-                #  TODO: transform to /map
-                rospy.logerr("Conversion to /map not yet implemented")
-                pass
             json_entity += ', "pose": { "x": %f, "y": %f, "z": %f, "X": %f, "Y": %f, "Z": %f }' % (t.x(), t.y(), t.z(), X, Y, Z)
 
         if flags or add_flags or remove_flags:

--- a/robot_skills/src/robot_skills/world_model_ed.py
+++ b/robot_skills/src/robot_skills/world_model_ed.py
@@ -157,7 +157,7 @@ class ED:
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def update_entity(self, id, type = None, kdlFrame = None, frame_id="/map", flags = None, add_flags = [], remove_flags = [], action = None):
+    def update_entity(self, id, type = None, kdlFrameStamped = None, flags = None, add_flags = [], remove_flags = [], action = None):
         """
         Updates entity
         :param id: entity id
@@ -175,11 +175,12 @@ class ED:
         if action:
             json_entity += ', "action": "%s"' % action
 
-        if kdlFrame:
-            Z, Y, X = kdlFrame.M.GetEulerZYX()
-            t = kdlFrame.p
-            if frame_id != "/map":
+        if kdlFrameStamped:
+            Z, Y, X = kdlFrameStamped.frame.M.GetEulerZYX()
+            t = kdlFrameStamped.frame.p
+            if kdlFrameStamped.frame_id != "/map":
                 #  TODO: transform to /map
+                rospy.logerr("Conversion to /map not yet implemented")
                 pass
             json_entity += ', "pose": { "x": %f, "y": %f, "z": %f, "X": %f, "Y": %f, "Z": %f }' % (t.x(), t.y(), t.z(), X, Y, Z)
 

--- a/robot_skills/src/robot_skills/world_model_ed.py
+++ b/robot_skills/src/robot_skills/world_model_ed.py
@@ -20,6 +20,7 @@ import tf
 import visualization_msgs.msg
 
 import PyKDL as kdl
+from robot_skills.util.kdl_conversions import poseMsgToKdlFrame, pointMsgToKdlVector, VectorStamped, kdlVectorToPointMsg
 import os
 
 
@@ -73,13 +74,11 @@ class ED:
     #                                             QUERYING
     # ----------------------------------------------------------------------------------------------------
 
-    def get_entities(self, type="", center_point=Point(), radius=0, id="", parse=True):
-        if isinstance(center_point, PointStamped):
-            center_point = self._transform_center_point_to_map(center_point)
-
+    def get_entities(self, type="", center_point=VectorStamped(), radius=0, id="", parse=True):
         self._publish_marker(center_point, radius)
 
-        query = SimpleQueryRequest(id=id, type=type, center_point=center_point, radius=radius)
+        center_point_in_map = center_point.projectToFrame("/map", self._tf_listener)
+        query = SimpleQueryRequest(id=id, type=type, center_point=kdlVectorToPointMsg(center_point_in_map.vector), radius=radius)
 
         try:
             entity_infos= self._ed_simple_query_srv(query).entities

--- a/robot_skills/src/robot_skills/world_model_ed.py
+++ b/robot_skills/src/robot_skills/world_model_ed.py
@@ -26,13 +26,17 @@ import os
 import yaml
 
 from .classification_result import ClassificationResult
-
 from robot_skills.util.entity import from_entity_info
+
+def _create_service_proxy(service_name, service_type, wait_service):
+    if wait_service:
+        rospy.wait_for_service(service_name)
+    return rospy.ServiceProxy(service_name, service_type)
 
 
 class Navigation:
     def __init__(self, robot_name, tf_listener, wait_service=False):
-        self._get_constraint_srv = rospy.ServiceProxy('/%s/ed/navigation/get_constraint'%robot_name, GetGoalConstraint)
+        self._get_constraint_srv = _create_service_proxy('/%s/ed/navigation/get_constraint'%robot_name, GetGoalConstraint, wait_service)
 
     def get_position_constraint(self, entity_id_area_name_map):
         try:
@@ -50,17 +54,14 @@ class Navigation:
 class ED:
 
     def __init__(self, robot_name, tf_listener, wait_service=False):
-        self._ed_simple_query_srv = rospy.ServiceProxy('/%s/ed/simple_query'%robot_name, SimpleQuery)
-        self._ed_entity_info_query_srv = rospy.ServiceProxy('/%s/ed/gui/get_entity_info'%robot_name, GetEntityInfo)
-        self._ed_update_srv = rospy.ServiceProxy('/%s/ed/update'%robot_name, UpdateSrv)
-        self._ed_kinect_update_srv = rospy.ServiceProxy('/%s/ed/kinect/update'%robot_name, ed_sensor_integration.srv.Update)
-
-        self._ed_classify_srv = rospy.ServiceProxy('/%s/ed/classify'%robot_name, Classify)
-        self._ed_configure_srv = rospy.ServiceProxy('/%s/ed/configure'%robot_name, Configure)
-
-        self._ed_reset_srv = rospy.ServiceProxy('/%s/ed/reset'%robot_name, ed.srv.Reset)
-
-        self._ed_get_image_srv = rospy.ServiceProxy('/%s/ed/kinect/get_image'%robot_name, ed_sensor_integration.srv.GetImage)
+        self._ed_simple_query_srv = _create_service_proxy('/%s/ed/simple_query'%robot_name, SimpleQuery, wait_service)
+        self._ed_entity_info_query_srv = _create_service_proxy('/%s/ed/gui/get_entity_info'%robot_name, GetEntityInfo, wait_service)
+        self._ed_update_srv = _create_service_proxy('/%s/ed/update'%robot_name, UpdateSrv, wait_service)
+        self._ed_kinect_update_srv = _create_service_proxy('/%s/ed/kinect/update'%robot_name, ed_sensor_integration.srv.Update, wait_service)
+        self._ed_classify_srv = _create_service_proxy('/%s/ed/classify'%robot_name, Classify, wait_service)
+        self._ed_configure_srv = _create_service_proxy('/%s/ed/configure'%robot_name, Configure, wait_service)
+        self._ed_reset_srv = _create_service_proxy('/%s/ed/reset'%robot_name, ed.srv.Reset, wait_service)
+        self._ed_get_image_srv = _create_service_proxy('/%s/ed/kinect/get_image'%robot_name, ed_sensor_integration.srv.GetImage, wait_service)
 
         self._tf_listener = tf_listener
 
@@ -146,8 +147,7 @@ class ED:
     #                                             UPDATING
     # ----------------------------------------------------------------------------------------------------
 
-    def reset(self, keep_all_shapes=False):
-
+    def reset(self, keep_all_shapes=True):
         try:
             self._ed_reset_srv(keep_all_shapes=keep_all_shapes)
         except rospy.ServiceException, e:

--- a/robot_skills/src/robot_skills/world_model_ed.py
+++ b/robot_skills/src/robot_skills/world_model_ed.py
@@ -156,7 +156,7 @@ class ED:
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def update_entity(self, id, type = None, kdlFrameStamped = None, flags = None, add_flags = [], remove_flags = [], action = None):
+    def update_entity(self, id, type=None, frame_stamped=None, flags=None, add_flags=[], remove_flags=[], action=None):
         """
         Updates entity
         :param id: entity id
@@ -174,12 +174,12 @@ class ED:
         if action:
             json_entity += ', "action": "%s"' % action
 
-        if kdlFrameStamped:
-            if kdlFrameStamped.frame_id != "/map":
-                kdlFrameStamped = kdlFrameStamped.projectToFrame("/map", self._tf_listener)
+        if frame_stamped:
+            if frame_stamped.frame_id != "/map":
+                frame_stamped = frame_stamped.projectToFrame("/map", self._tf_listener)
 
-            Z, Y, X = kdlFrameStamped.frame.M.GetEulerZYX()
-            t = kdlFrameStamped.frame.p
+            Z, Y, X = frame_stamped.frame.M.GetEulerZYX()
+            t = frame_stamped.frame.p
             json_entity += ', "pose": { "x": %f, "y": %f, "z": %f, "X": %f, "Y": %f, "Z": %f }' % (t.x(), t.y(), t.z(), X, Y, Z)
 
         if flags or add_flags or remove_flags:

--- a/robot_skills/src/robot_skills/world_model_ed.py
+++ b/robot_skills/src/robot_skills/world_model_ed.py
@@ -372,9 +372,9 @@ class ED:
         marker.header.frame_id = "/map"
         marker.header.stamp = rospy.Time.now()
         marker.type = 2
-        marker.pose.position.x = center_point.x
-        marker.pose.position.y = center_point.y
-        marker.pose.position.z = center_point.z
+        marker.pose.position.x = center_point.vector.x()
+        marker.pose.position.y = center_point.vector.y()
+        marker.pose.position.z = center_point.vector.z()
         marker.lifetime = rospy.Duration(20.0)
         marker.scale.x = radius
         marker.scale.y = radius

--- a/robot_skills/src/robot_skills/world_model_ed.py
+++ b/robot_skills/src/robot_skills/world_model_ed.py
@@ -157,7 +157,7 @@ class ED:
 
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    def update_entity(self, id, type = None, posestamped = None, flags = None, add_flags = [], remove_flags = [], action = None):
+    def update_entity(self, id, type = None, kdlFrame = None, flags = None, add_flags = [], remove_flags = [], action = None):
         """
         Updates entity
         :param id: entity id
@@ -175,10 +175,10 @@ class ED:
         if action:
             json_entity += ', "action": "%s"' % action
 
-        if posestamped:
-            X, Y, Z = tf.transformations.euler_from_quaternion([posestamped.pose.orientation.x, posestamped.pose.orientation.y, posestamped.pose.orientation.z, posestamped.pose.orientation.w])
-            t = posestamped.pose.position
-            json_entity += ', "pose": { "x": %f, "y": %f, "z": %f, "X": %f, "Y": %f, "Z": %f }' % (t.x, t.y, t.z, X, Y, Z)
+        if kdlFrame:
+            Z, Y, X = kdlFrame.M.GetEulerZYX()
+            t = kdlFrame.p
+            json_entity += ', "pose": { "x": %f, "y": %f, "z": %f, "X": %f, "Y": %f, "Z": %f }' % (t.x(), t.y(), t.z(), X, Y, Z)
 
         if flags or add_flags or remove_flags:
             json_entity += ', "flags": ['

--- a/robot_skills/test/test_full.py
+++ b/robot_skills/test/test_full.py
@@ -47,57 +47,43 @@ def test_head(amigo):
 
     max_err = 0.02
 
-    vs = VectorStamped(frame_id='/amigo/torso')
-
     # straight
-    vs.vector.x(0.4)
-    vs.vector.y(0)
-    vs.vector.z(10)
+    vs = VectorStamped(x=0.4, z=10, frame_id='/amigo/torso')
     amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head straight",      in_bounds(joint_positions['neck_pan_joint'], 0, max_err)
                                 and in_bounds(joint_positions['neck_tilt_joint'], 0, max_err))
 
     # up
-    vs.vector.x(0.5)
-    vs.vector.y(0)
-    vs.vector.z(1)
+    vs = VectorStamped(x=0.5, z=1, frame_id='/amigo/torso')
     amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head up",      in_bounds(joint_positions['neck_pan_joint'], 0, max_err)
                           and in_bounds(joint_positions['neck_tilt_joint'], -0.26, max_err))
 
     # down
-    vs.vector.x(-0.4)
-    vs.vector.y(0)
-    vs.vector.z(1)
+    vs = VectorStamped(x=-0.4, z=1, frame_id='/amigo/torso')
     amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head down",      in_bounds(joint_positions['neck_pan_joint'], 0, max_err)
                             and in_bounds(joint_positions['neck_tilt_joint'], 0.54, max_err))
 
     # right
-    vs.vector.x(0.4)
-    vs.vector.y(100)
-    vs.vector.z(1)
+    vs = VectorStamped(x=0.4, y=100, z=1, frame_id='/amigo/torso')
     amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head right",      in_bounds(joint_positions['neck_pan_joint'], -1.547, max_err)
                             and in_bounds(joint_positions['neck_tilt_joint'], 0, max_err))
 
     # left
-    vs.vector.x(0.4)
-    vs.vector.y(-100)
-    vs.vector.z(1)
+    vs = VectorStamped(x=0.4, y=-100, z=1, frame_id='/amigo/torso')
     amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head left",      in_bounds(joint_positions['neck_pan_joint'], 1.547, max_err)
                              and in_bounds(joint_positions['neck_tilt_joint'], 0, max_err))
 
     # straight
-    vs.vector.x(0.4)
-    vs.vector.y(0)
-    vs.vector.z(10)
+    vs = VectorStamped(x=0.4, z=10, frame_id='/amigo/torso')
     amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head straight",      in_bounds(joint_positions['neck_pan_joint'], 0, max_err)

--- a/robot_skills/test/test_full.py
+++ b/robot_skills/test/test_full.py
@@ -4,6 +4,7 @@ import rospy
 
 import robot_skills
 import robot_skills.amigo
+from robot_skills.util.kdl_conversions import VectorStamped
 
 import geometry_msgs
 import sensor_msgs
@@ -46,59 +47,58 @@ def test_head(amigo):
 
     max_err = 0.02
 
-    p = geometry_msgs.msg.PointStamped()
-    p.header.frame_id = '/amigo/torso'
+    vs = VectorStamped(frame_id='/amigo/torso')
 
     # straight
-    p.point.x = 0.4
-    p.point.y = 0
-    p.point.z = 10
-    amigo.head.look_at_point(p)
+    vs.vector.x(0.4)
+    vs.vector.y(0)
+    vs.vector.z(10)
+    amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head straight",      in_bounds(joint_positions['neck_pan_joint'], 0, max_err)
                                 and in_bounds(joint_positions['neck_tilt_joint'], 0, max_err))
 
     # up
-    p.point.x = 0.5
-    p.point.y = 0
-    p.point.z = 1
-    amigo.head.look_at_point(p)
+    vs.vector.x(0.5)
+    vs.vector.y(0)
+    vs.vector.z(1)
+    amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head up",      in_bounds(joint_positions['neck_pan_joint'], 0, max_err)
                           and in_bounds(joint_positions['neck_tilt_joint'], -0.26, max_err))
 
     # down
-    p.point.x = -0.4
-    p.point.y = 0
-    p.point.z = 1
-    amigo.head.look_at_point(p)
+    vs.vector.x(-0.4)
+    vs.vector.y(0)
+    vs.vector.z(1)
+    amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head down",      in_bounds(joint_positions['neck_pan_joint'], 0, max_err)
                             and in_bounds(joint_positions['neck_tilt_joint'], 0.54, max_err))
 
     # right
-    p.point.x = 0.4
-    p.point.y = 100
-    p.point.z = 1
-    amigo.head.look_at_point(p)
+    vs.vector.x(0.4)
+    vs.vector.y(100)
+    vs.vector.z(1)
+    amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head right",      in_bounds(joint_positions['neck_pan_joint'], -1.547, max_err)
                             and in_bounds(joint_positions['neck_tilt_joint'], 0, max_err))
 
     # left
-    p.point.x = 0.4
-    p.point.y = -100
-    p.point.z = 1
-    amigo.head.look_at_point(p)
+    vs.vector.x(0.4)
+    vs.vector.y(-100)
+    vs.vector.z(1)
+    amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head left",      in_bounds(joint_positions['neck_pan_joint'], 1.547, max_err)
                              and in_bounds(joint_positions['neck_tilt_joint'], 0, max_err))
 
     # straight
-    p.point.x = 0.4
-    p.point.y = 0
-    p.point.z = 10
-    amigo.head.look_at_point(p)
+    vs.vector.x(0.4)
+    vs.vector.y(0)
+    vs.vector.z(10)
+    amigo.head.look_at_point(vs)
     # print str(joint_positions['neck_pan_joint']) + " " + str(joint_positions['neck_tilt_joint'])
     show_test("head straight",      in_bounds(joint_positions['neck_pan_joint'], 0, max_err)
                                 and in_bounds(joint_positions['neck_tilt_joint'], 0, max_err))

--- a/robot_skills/test/test_spindle_goals.py
+++ b/robot_skills/test/test_spindle_goals.py
@@ -1,0 +1,25 @@
+#! /usr/bin/env python
+import roslib; roslib.load_manifest('robot_skills')
+import rospy
+
+import robot_skills
+import robot_skills.amigo
+
+import geometry_msgs
+import sensor_msgs
+import amigo_msgs
+import random
+import time
+
+if __name__ == "__main__":
+    rospy.init_node('amigo_skills_test_full')
+
+    amigo = robot_skills.amigo.Amigo(wait_services=True)
+    amigo.leftArm.reset()
+    amigo.rightArm.reset()
+    time.sleep(1.0)
+    while not rospy.is_shutdown():
+        amigo.torso._send_goal([random.random()])
+        rospy.sleep(rospy.Duration(0.1))
+
+

--- a/robot_smach_states/src/robot_smach_states/console-nl.py
+++ b/robot_smach_states/src/robot_smach_states/console-nl.py
@@ -103,11 +103,11 @@ def parse_object(p, robot):
 
     # Simply skip articles if they are there
     if p.read("a", "an", "the"):
-        pass       
+        pass
 
     # Check adjectives
     while True:
-        if p.read("red", "green", "blue", "black", "white" "pink", "purple", "orange", "brown", "grey", "yellow"):    
+        if p.read("red", "green", "blue", "black", "white" "pink", "purple", "orange", "brown", "grey", "yellow"):
             color = p.last_read[0]
         elif p.read("small", "big", "medium"):
             size = p.last_read[0]
@@ -145,7 +145,7 @@ def parse_object(p, robot):
     else:
         entities = robot.ed.get_entities(parse=False)
 
-    robot_pos = robot.base.get_location().pose.p
+    robot_pos = robot.base.get_location().p
 
     # Sort entities by distance
     entities = sorted(entities, key=lambda entity: entity.distance_to_2d(robot_pos))
@@ -196,7 +196,7 @@ def move(p, robot):
     ACTION = SmachAction(machine)
     ACTION.start()
 
-# ----------------------------------------------------------------------------------------------------  
+# ----------------------------------------------------------------------------------------------------
 
 def lookat(p, robot):
 
@@ -313,7 +313,7 @@ class REPL(cmd.Cmd):
             elif p.read("look at", "lookat"):
                 lookat(p, self.robot)
             elif p.read("show"):
-                show(p, self.robot)                
+                show(p, self.robot)
             elif p.read("stop"):
                 stop()
             else:

--- a/robot_smach_states/src/robot_smach_states/human_interaction/human_interaction.py
+++ b/robot_smach_states/src/robot_smach_states/human_interaction/human_interaction.py
@@ -9,7 +9,6 @@ from robot_smach_states.state import State
 
 import robot_smach_states.util.designators as ds
 from robot_smach_states.utility import WaitForDesignator
-import robot_skills.util.msg_constructors as gm
 from smach_ros import SimpleActionState
 from dragonfly_speech_recognition.srv import GetSpeechResponse
 import time
@@ -215,7 +214,6 @@ class WaitForPersonInFront(WaitForDesignator):
 
     def __init__(self, robot, attempts = 1, sleep_interval = 1):
         # TODO: add center_point in front of the robot and radius of the search on ds.EdEntityDesignator
-        # human_entity = ds.EdEntityDesignator(robot, center_point=gm.PointStamped(x=1.0, frame_id="base_link"), radius=1, id="human")
         human_entity = ds.EdEntityDesignator(robot, type="human")
         ds.WaitForDesignator.__init__(self, robot, human_entity, attempts, sleep_interval)
 

--- a/robot_smach_states/src/robot_smach_states/manipulation/grab.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grab.py
@@ -59,8 +59,7 @@ class PrepareEdGrasp(smach.State):
         arm.send_gripper_goal('open', timeout=0.0)
 
         # Make sure the head looks at the entity
-        pos = entity.pose.position
-        self.robot.head.look_at_point(VectorStamped(pos.x, pos.y, pos.z, "/map"), timeout=0.0)
+        self.robot.head.look_at_point(VectorStamped(vector=entity._pose.p, frame_id="/map"), timeout=0.0)
 
         return 'succeeded'
 

--- a/robot_smach_states/src/robot_smach_states/manipulation/grab.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grab.py
@@ -3,6 +3,7 @@ import math
 import rospy
 import smach
 import tf
+from robot_skills.utilkdl_conversions import kdlFrameFromXYZRPY
 
 from robot_skills.util.entity import Entity
 import robot_skills.util.msg_constructors as msgs
@@ -188,7 +189,7 @@ class PickUp(smach.State):
 
         # Grasp
         # rospy.loginfo('Start grasping')
-        if not arm.send_goal(goal_bl.x, goal_bl.y, goal_bl.z, 0, 0, 0,
+        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z, 0, 0, 0),
                              frame_id='/'+self.robot.robot_name+'/base_link',
                              timeout=20, pre_grasp=True,
                              allowed_touch_objects=[grab_entity.id]
@@ -210,7 +211,7 @@ class PickUp(smach.State):
             roll = 0.3
         else:
             roll = -0.3
-        if not arm.send_goal(goal_bl.x, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0,
+        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0),
                              frame_id='/'+self.robot.robot_name+'/base_link',
                              timeout=20, allowed_touch_objects=[grab_entity.id]
                              ):
@@ -222,7 +223,7 @@ class PickUp(smach.State):
             roll = 0.6
         else:
             roll = -0.6
-        if not arm.send_goal(goal_bl.x - 0.1, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0,
+        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x - 0.1, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0),
                              frame_id='/'+self.robot.robot_name+'/base_link',
                              timeout=0.0, allowed_touch_objects=[grab_entity.id]
                              ):

--- a/robot_smach_states/src/robot_smach_states/manipulation/grab.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grab.py
@@ -3,7 +3,7 @@ import math
 import rospy
 import smach
 import tf
-from robot_skills.utilkdl_conversions import kdlFrameFromXYZRPY
+from robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY
 
 from robot_skills.util.entity import Entity
 import robot_skills.util.msg_constructors as msgs

--- a/robot_smach_states/src/robot_smach_states/manipulation/grab.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grab.py
@@ -3,7 +3,7 @@ import math
 import rospy
 import smach
 import tf
-from robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY
+from robot_skills.util.kdl_conversions import kdlFrameStampedFromXYZRPY
 
 from robot_skills.util.entity import Entity
 import robot_skills.util.msg_constructors as msgs
@@ -189,8 +189,7 @@ class PickUp(smach.State):
 
         # Grasp
         # rospy.loginfo('Start grasping')
-        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z, 0, 0, 0),
-                             frame_id='/'+self.robot.robot_name+'/base_link',
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z, 0, 0, 0, frame_id='/'+self.robot.robot_name+'/base_link'),
                              timeout=20, pre_grasp=True,
                              allowed_touch_objects=[grab_entity.id]
                              ):
@@ -211,8 +210,7 @@ class PickUp(smach.State):
             roll = 0.3
         else:
             roll = -0.3
-        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0),
-                             frame_id='/'+self.robot.robot_name+'/base_link',
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0, frame_id='/'+self.robot.robot_name+'/base_link'),
                              timeout=20, allowed_touch_objects=[grab_entity.id]
                              ):
             rospy.logerr('Failed lift')
@@ -223,8 +221,7 @@ class PickUp(smach.State):
             roll = 0.6
         else:
             roll = -0.6
-        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x - 0.1, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0),
-                             frame_id='/'+self.robot.robot_name+'/base_link',
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(goal_bl.x - 0.1, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0, frame_id='/'+self.robot.robot_name+'/base_link'),
                              timeout=0.0, allowed_touch_objects=[grab_entity.id]
                              ):
             rospy.logerr('Failed retract')

--- a/robot_smach_states/src/robot_smach_states/manipulation/grab.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grab.py
@@ -3,7 +3,7 @@ import math
 import rospy
 import smach
 import tf
-from robot_skills.util.kdl_conversions import kdlFrameStampedFromXYZRPY
+from robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY
 
 from robot_skills.util.entity import Entity
 import robot_skills.util.msg_constructors as msgs
@@ -189,7 +189,7 @@ class PickUp(smach.State):
 
         # Grasp
         # rospy.loginfo('Start grasping')
-        if not arm.send_goal(kdlFrameStampedFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z, 0, 0, 0, frame_id='/'+self.robot.robot_name+'/base_link'),
+        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z, 0, 0, 0),
                              timeout=20, pre_grasp=True,
                              allowed_touch_objects=[grab_entity.id]
                              ):
@@ -210,7 +210,7 @@ class PickUp(smach.State):
             roll = 0.3
         else:
             roll = -0.3
-        if not arm.send_goal(kdlFrameStampedFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0, frame_id='/'+self.robot.robot_name+'/base_link'),
+        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0),
                              timeout=20, allowed_touch_objects=[grab_entity.id]
                              ):
             rospy.logerr('Failed lift')
@@ -221,7 +221,7 @@ class PickUp(smach.State):
             roll = 0.6
         else:
             roll = -0.6
-        if not arm.send_goal(kdlFrameStampedFromXYZRPY(goal_bl.x - 0.1, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0, frame_id='/'+self.robot.robot_name+'/base_link'),
+        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x - 0.1, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0),
                              timeout=0.0, allowed_touch_objects=[grab_entity.id]
                              ):
             rospy.logerr('Failed retract')

--- a/robot_smach_states/src/robot_smach_states/manipulation/grab.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grab.py
@@ -189,12 +189,20 @@ class PickUp(smach.State):
 
         arm.occupied_by = grab_entity
 
+        # First set orientation to 0
+        goal_bl.frame.M.DoRotX(0)
+        goal_bl.frame.M.DoRotY(0)
+        goal_bl.frame.M.DoRotZ(0)
+
         # Lift
         # rospy.loginfo('Start lifting')
         if arm.side == "left":
             roll = 0.3
         else:
             roll = -0.3
+
+        goal_bl.frame.M.DoRotZ(0) # First set roll to 0
+        goal_bl.frame.M.DoRotZ(roll)  # So we don't rotate by the roll but effectively set it
         if not arm.send_goal(goal_bl, timeout=20, allowed_touch_objects=[grab_entity.id]):
             rospy.logerr('Failed lift')
 
@@ -204,6 +212,10 @@ class PickUp(smach.State):
             roll = 0.6
         else:
             roll = -0.6
+
+        goal_bl.frame.p.z(goal_bl.frame.p.z() + 0.05)
+        goal_bl.frame.M.DoRotZ(0) # First set roll to 0
+        goal_bl.frame.M.DoRotZ(roll)  # So we don't rotate by the roll but effectively set it
         if not arm.send_goal(goal_bl, timeout=0.0, allowed_touch_objects=[grab_entity.id]):
             rospy.logerr('Failed retract')
 

--- a/robot_smach_states/src/robot_smach_states/manipulation/grab.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grab.py
@@ -3,7 +3,7 @@ import math
 import rospy
 import smach
 import tf
-from robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY
+from robot_skills.util.kdl_conversions import kdlFrameStampedFromXYZRPY
 
 from robot_skills.util.entity import Entity
 import robot_skills.util.msg_constructors as msgs
@@ -189,7 +189,7 @@ class PickUp(smach.State):
 
         # Grasp
         # rospy.loginfo('Start grasping')
-        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z, 0, 0, 0),
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z, 0, 0, 0, "/"+self.robot.robot_name+"/base_link"),
                              timeout=20, pre_grasp=True,
                              allowed_touch_objects=[grab_entity.id]
                              ):
@@ -210,7 +210,7 @@ class PickUp(smach.State):
             roll = 0.3
         else:
             roll = -0.3
-        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0),
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(goal_bl.x, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0, "/"+self.robot.robot_name+"/base_link"),
                              timeout=20, allowed_touch_objects=[grab_entity.id]
                              ):
             rospy.logerr('Failed lift')
@@ -221,7 +221,7 @@ class PickUp(smach.State):
             roll = 0.6
         else:
             roll = -0.6
-        if not arm.send_goal(kdlFrameFromXYZRPY(goal_bl.x - 0.1, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0),
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(goal_bl.x - 0.1, goal_bl.y, goal_bl.z + 0.05, roll, 0.0, 0.0, "/"+self.robot.robot_name+"/base_link"),
                              timeout=0.0, allowed_touch_objects=[grab_entity.id]
                              ):
             rospy.logerr('Failed retract')

--- a/robot_smach_states/src/robot_smach_states/manipulation/grab.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grab.py
@@ -3,7 +3,7 @@ import math
 import rospy
 import smach
 import tf
-from robot_skills.util.kdl_conversions import kdlFrameStampedFromXYZRPY
+from robot_skills.util.kdl_conversions import kdlFrameStampedFromXYZRPY, VectorStamped
 
 from robot_skills.util.entity import Entity
 import robot_skills.util.msg_constructors as msgs
@@ -60,7 +60,7 @@ class PrepareEdGrasp(smach.State):
 
         # Make sure the head looks at the entity
         pos = entity.pose.position
-        self.robot.head.look_at_point(msgs.PointStamped(pos.x, pos.y, pos.z, "/map"), timeout=0.0)
+        self.robot.head.look_at_point(VectorStamped(pos.x, pos.y, pos.z, "/map"), timeout=0.0)
 
         return 'succeeded'
 

--- a/robot_smach_states/src/robot_smach_states/manipulation/grasp_point_determination.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grasp_point_determination.py
@@ -140,10 +140,10 @@ class GraspPointDeterminant(object):
             marker.id = i
             marker.type = marker.ARROW
             marker.action = marker.ADD
-            marker.pose.position.x = c['vector'].p.x()
-            marker.pose.position.y = c['vector'].p.y()
-            marker.pose.position.z = c['vector'].p.z()
-            (rx, ry, rz, rw) = c['vector'].M.GetQuaternion()
+            marker.pose.position.x = c['vector'].frame.p.x()
+            marker.pose.position.y = c['vector'].frame.p.y()
+            marker.pose.position.z = c['vector'].frame.p.z()
+            (rx, ry, rz, rw) = c['vector'].frame.M.GetQuaternion()
             marker.pose.orientation.x = rx
             marker.pose.orientation.y = ry
             marker.pose.orientation.z = rz

--- a/robot_smach_states/src/robot_smach_states/manipulation/grasp_point_determination.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grasp_point_determination.py
@@ -47,8 +47,7 @@ class GraspPointDeterminant(object):
         # import ipdb;ipdb.set_trace()
 
         ''' Get robot pose as a kdl frame (is required later on) '''
-        robot_pose = self._robot.base.get_location()
-        robot_frame = poseMsgToKdlFrame(robot_pose.pose)
+        robot_frame = self._robot.base.get_location()
         robot_frame_inv = robot_frame.Inverse()
 
         ''' Loop over lines of chull '''

--- a/robot_smach_states/src/robot_smach_states/manipulation/grasp_point_determination.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grasp_point_determination.py
@@ -5,7 +5,7 @@ import math
 import rospy
 from visualization_msgs.msg import Marker, MarkerArray
 from robot_smach_states.util.geometry_helpers import offsetConvexHull
-from robot_skills.util.kdl_conversions import pointMsgToKdlVector, poseMsgToKdlFrame, FrameStamped
+from robot_skills.util.kdl_conversions import pointMsgToKdlVector, poseMsgToKdlFrame, FrameStamped, kdlFrameToPoseMsg
 
 
 class GraspPointDeterminant(object):
@@ -135,19 +135,12 @@ class GraspPointDeterminant(object):
         msg = MarkerArray()
         for i, c in enumerate(candidates):
             marker = Marker()
-            marker.header.frame_id = "/map"
+            marker.header.frame_id = c['vector'].frame_id
             marker.header.stamp = rospy.Time.now()
             marker.id = i
             marker.type = marker.ARROW
             marker.action = marker.ADD
-            marker.pose.position.x = c['vector'].frame.p.x()
-            marker.pose.position.y = c['vector'].frame.p.y()
-            marker.pose.position.z = c['vector'].frame.p.z()
-            (rx, ry, rz, rw) = c['vector'].frame.M.GetQuaternion()
-            marker.pose.orientation.x = rx
-            marker.pose.orientation.y = ry
-            marker.pose.orientation.z = rz
-            marker.pose.orientation.w = rw
+            marker.pose = kdlFrameToPoseMsg(c['vector'].frame)
             if i == 0: # The 'best' one is blue...
                 marker.color.b = 1.0
             elif 'score' in c:

--- a/robot_smach_states/src/robot_smach_states/manipulation/manipulation.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/manipulation.py
@@ -2,14 +2,11 @@ import rospy
 import smach
 from robot_skills.util import transformations
 
-
-import geometry_msgs
 from ed.msg import EntityInfo
 
 from robot_smach_states.human_interaction import Say
 from robot_smach_states.reset import ResetPart
 from robot_smach_states.utility import LockDesignator, UnlockDesignator
-import robot_skills.util.msg_constructors as msgs
 from robot_skills.arms import ArmState
 from robot_smach_states.util.designators import PointStampedOfEntityDesignator, LockingDesignator
 

--- a/robot_smach_states/src/robot_smach_states/manipulation/manipulation.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/manipulation.py
@@ -8,7 +8,7 @@ from robot_smach_states.human_interaction import Say
 from robot_smach_states.reset import ResetPart
 from robot_smach_states.utility import LockDesignator, UnlockDesignator
 from robot_skills.arms import ArmState
-from robot_smach_states.util.designators import PointStampedOfEntityDesignator, LockingDesignator
+from robot_smach_states.util.designators import LockingDesignator
 
 from robot_smach_states.util.designators import check_type
 from robot_skills.arms import Arm

--- a/robot_smach_states/src/robot_smach_states/manipulation/place.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/place.py
@@ -3,6 +3,7 @@ import rospy
 import smach
 
 import robot_skills.util.transformations as transformations
+import robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY
 from robot_smach_states.navigation import NavigateToPlace
 
 from robot_smach_states.state import State
@@ -118,19 +119,19 @@ class Put(smach.State):
             height = 0.8
 
         # Pre place
-        if not arm.send_goal(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0,
+        if not arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0),
                              timeout=10, pre_grasp=False, frame_id="/{0}/base_link".format(self._robot.robot_name)):
             # If we can't place, try a little closer
             place_pose_bl.x -= 0.05
             rospy.loginfo("Retrying preplace")
-            if not arm.send_goal(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0,
+            if not arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0),
                              timeout=10, pre_grasp=False, frame_id="/{0}/base_link".format(self._robot.robot_name)):
                 rospy.logwarn("Cannot pre-place the object")
                 arm.cancel_goals()
                 return 'failed'
 
         # Place
-        if not arm.send_goal(place_pose_bl.x, place_pose_bl.y, height+0.15, 0.0, 0.0, 0.0,
+        if not arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.15, 0.0, 0.0, 0.0),
                              timeout=10, pre_grasp=False, frame_id="/{0}/base_link".format(self._robot.robot_name)):
             rospy.logwarn("Cannot place the object, dropping it...")
 
@@ -148,7 +149,7 @@ class Put(smach.State):
         arm.occupied_by = None
 
         # Retract
-        arm.send_goal(place_pose_bl.x - 0.1, place_pose_bl.y, place_pose_bl.z + 0.05, 0.0, 0.0, 0.0,
+        arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x - 0.1, place_pose_bl.y, place_pose_bl.z + 0.05, 0.0, 0.0, 0.0),
                              frame_id='/'+self._robot.robot_name+'/base_link',
                              timeout=0.0)
 

--- a/robot_smach_states/src/robot_smach_states/manipulation/place.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/place.py
@@ -3,7 +3,7 @@ import rospy
 import smach
 
 import robot_skills.util.transformations as transformations
-from robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY, kdlVectorToPointMsg, FrameStamped
+from robot_skills.util.kdl_conversions import kdlFrameStampedFromXYZRPY, kdlVectorToPointMsg, FrameStamped
 from robot_smach_states.navigation import NavigateToPlace
 
 from robot_smach_states.state import State
@@ -118,19 +118,19 @@ class Put(smach.State):
             height = 0.8
 
         # Pre place
-        if not arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0), frame_id="/{0}/base_link".format(self._robot.robot_name),
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
                              timeout=10, pre_grasp=False):
             # If we can't place, try a little closer
             place_pose_bl.x -= 0.05
             rospy.loginfo("Retrying preplace")
-            if not arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0), frame_id="/{0}/base_link".format(self._robot.robot_name),
+            if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
                              timeout=10, pre_grasp=False):
                 rospy.logwarn("Cannot pre-place the object")
                 arm.cancel_goals()
                 return 'failed'
 
         # Place
-        if not arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.15, 0.0, 0.0, 0.0), frame_id="/{0}/base_link".format(self._robot.robot_name),
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.15, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
                              timeout=10, pre_grasp=False):
             rospy.logwarn("Cannot place the object, dropping it...")
 
@@ -148,7 +148,7 @@ class Put(smach.State):
         arm.occupied_by = None
 
         # Retract
-        arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x - 0.1, place_pose_bl.y, place_pose_bl.z + 0.05, 0.0, 0.0, 0.0), frame_id='/'+self._robot.robot_name+'/base_link',
+        arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.x - 0.1, place_pose_bl.y, place_pose_bl.z + 0.05, 0.0, 0.0, 0.0, frame_id='/'+self._robot.robot_name+'/base_link'),
                              timeout=0.0)
 
         self._robot.base.force_drive(-0.125, 0, 0, 1.5)

--- a/robot_smach_states/src/robot_smach_states/manipulation/place.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/place.py
@@ -3,7 +3,7 @@ import rospy
 import smach
 
 import robot_skills.util.transformations as transformations
-import robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY
+from robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY
 from robot_smach_states.navigation import NavigateToPlace
 
 from robot_smach_states.state import State
@@ -12,6 +12,7 @@ from robot_smach_states.util.designators import check_type
 from robot_skills.util.entity import Entity
 from robot_skills.arms import Arm
 from geometry_msgs.msg import PoseStamped
+from PyKDL import Frame
 
 class PreparePlace(smach.State):
     def __init__(self, robot, placement_pose, arm):
@@ -24,7 +25,7 @@ class PreparePlace(smach.State):
         smach.State.__init__(self, outcomes=['succeeded', 'failed'])
 
         # Check types or designator resolve types
-        check_type(placement_pose, PoseStamped)
+        check_type(placement_pose, Frame)
         check_type(arm, Arm)
 
         # Assign member variables
@@ -53,7 +54,7 @@ class PreparePlace(smach.State):
         # When the arm is in the prepare_place configuration, the grippoint is approximately at height torso_pos + 0.6
         # Hence, we want the torso to go to the place height - 0.6
         # Note: this is awefully hardcoded for AMIGO
-        torso_goal = placement_pose.pose.position.z - 0.6
+        torso_goal = placement_pose.p.z() - 0.6
         torso_goal = max(0.09, min(0.4, torso_goal))
         rospy.logwarn("Torso goal before placing: {0}".format(torso_goal))
         self._robot.torso._send_goal(torso_pos=[torso_goal])
@@ -76,7 +77,7 @@ class Put(smach.State):
 
         # Check types or designator resolve types
         check_type(item_to_place, Entity)
-        check_type(placement_pose, PoseStamped)
+        check_type(placement_pose, Frame)
         check_type(arm, Arm)
 
         # Assign member variables
@@ -139,7 +140,7 @@ class Put(smach.State):
         if not place_entity:
             rospy.logerr("Arm not holding an entity to place. This should never happen")
         else:
-            self._robot.ed.update_entity(place_entity.id, posestamped=placement_pose)
+            self._robot.ed.update_entity(place_entity.id, kdlFrame=placement_pose)
             arm.occupied_by = None
 
         # Open gripper
@@ -182,7 +183,7 @@ class Place(smach.StateMachine):
 
         #Check types or designator resolve types
         assert(item_to_place.resolve_type == Entity or type(item_to_place) == Entity)
-        assert(place_pose.resolve_type == PoseStamped or type(place_pose) == PoseStamped)
+        assert(place_pose.resolve_type == Frame or type(place_pose) == Frame)
         assert(arm.resolve_type == Arm or type(arm) == Arm)
 
         with self:

--- a/robot_smach_states/src/robot_smach_states/manipulation/place.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/place.py
@@ -3,7 +3,7 @@ import rospy
 import smach
 
 import robot_skills.util.transformations as transformations
-from robot_skills.util.kdl_conversions import kdlFrameFromXYZRPY, kdlVectorToPointMsg
+from robot_skills.util.kdl_conversions import kdlFrameStampedFromXYZRPY, kdlVectorToPointMsg, FrameStamped
 from robot_smach_states.navigation import NavigateToPlace
 
 from robot_smach_states.state import State
@@ -11,8 +11,6 @@ from robot_smach_states.state import State
 from robot_smach_states.util.designators import check_type
 from robot_skills.util.entity import Entity
 from robot_skills.arms import Arm
-from geometry_msgs.msg import PoseStamped
-from PyKDL import Frame
 
 class PreparePlace(smach.State):
     def __init__(self, robot, placement_pose, arm):
@@ -25,7 +23,7 @@ class PreparePlace(smach.State):
         smach.State.__init__(self, outcomes=['succeeded', 'failed'])
 
         # Check types or designator resolve types
-        check_type(placement_pose, (Frame, str))
+        check_type(placement_pose, FrameStamped)
         check_type(arm, Arm)
 
         # Assign member variables
@@ -35,8 +33,8 @@ class PreparePlace(smach.State):
 
     def execute(self, userdata):
 
-        placement_pose, frame_id = self._placement_pose_designator.resolve()
-        if not placement_pose:
+        placement_fs, frame_id = self._placement_pose_designator.resolve()
+        if not placement_fs:
             rospy.logerr("Could not resolve placement_pose")
             return "failed"
 
@@ -54,7 +52,7 @@ class PreparePlace(smach.State):
         # When the arm is in the prepare_place configuration, the grippoint is approximately at height torso_pos + 0.6
         # Hence, we want the torso to go to the place height - 0.6
         # Note: this is awefully hardcoded for AMIGO
-        torso_goal = placement_pose.p.z() - 0.6
+        torso_goal = placement_fs.frame.p.z() - 0.6
         torso_goal = max(0.09, min(0.4, torso_goal))
         rospy.logwarn("Torso goal before placing: {0}".format(torso_goal))
         self._robot.torso._send_goal(torso_pos=[torso_goal])
@@ -77,7 +75,7 @@ class Put(smach.State):
 
         # Check types or designator resolve types
         check_type(item_to_place, Entity)
-        check_type(placement_pose, (Frame, str))
+        check_type(placement_pose, FrameStamped)
         check_type(arm, Arm)
 
         # Assign member variables
@@ -92,8 +90,8 @@ class Put(smach.State):
             rospy.logerr("Could not resolve item_to_place")
             #return "failed"
 
-        placement_pose, frame_id = self._placement_pose_designator.resolve()
-        if not placement_pose:
+        placement_fs = self._placement_pose_designator.resolve()
+        if not placement_fs:
             rospy.logerr("Could not resolve placement_pose")
             return "failed"
 
@@ -105,8 +103,8 @@ class Put(smach.State):
         rospy.loginfo("Placing")
 
         # placement_pose is a PyKDL.Frame
-        place_pose_bl = transformations.tf_transform(kdlVectorToPointMsg(placement_pose.p),
-                                                     frame_id,
+        place_pose_bl = transformations.tf_transform(kdlVectorToPointMsg(placement_fs.frame.p),
+                                                     placement_fs.frame_id,
                                                      self._robot.robot_name+'/base_link',
                                                      tf_listener=self._robot.tf_listener)
 
@@ -120,27 +118,27 @@ class Put(smach.State):
             height = 0.8
 
         # Pre place
-        if not arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0),
-                             timeout=10, pre_grasp=False, frame_id="/{0}/base_link".format(self._robot.robot_name)):
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
+                             timeout=10, pre_grasp=False):
             # If we can't place, try a little closer
             place_pose_bl.x -= 0.05
             rospy.loginfo("Retrying preplace")
-            if not arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0),
-                             timeout=10, pre_grasp=False, frame_id="/{0}/base_link".format(self._robot.robot_name)):
+            if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.2, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
+                             timeout=10, pre_grasp=False):
                 rospy.logwarn("Cannot pre-place the object")
                 arm.cancel_goals()
                 return 'failed'
 
         # Place
-        if not arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.15, 0.0, 0.0, 0.0),
-                             timeout=10, pre_grasp=False, frame_id="/{0}/base_link".format(self._robot.robot_name)):
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.x, place_pose_bl.y, height+0.15, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
+                             timeout=10, pre_grasp=False):
             rospy.logwarn("Cannot place the object, dropping it...")
 
         place_entity = arm.occupied_by
         if not place_entity:
             rospy.logerr("Arm not holding an entity to place. This should never happen")
         else:
-            self._robot.ed.update_entity(place_entity.id, kdlFrame=placement_pose)
+            self._robot.ed.update_entity(place_entity.id, kdlFrameStamped=placement_fs)
             arm.occupied_by = None
 
         # Open gripper
@@ -150,8 +148,7 @@ class Put(smach.State):
         arm.occupied_by = None
 
         # Retract
-        arm.send_goal(kdlFrameFromXYZRPY(place_pose_bl.x - 0.1, place_pose_bl.y, place_pose_bl.z + 0.05, 0.0, 0.0, 0.0),
-                             frame_id='/'+self._robot.robot_name+'/base_link',
+        arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.x - 0.1, place_pose_bl.y, place_pose_bl.z + 0.05, 0.0, 0.0, 0.0, frame_id='/'+self._robot.robot_name+'/base_link'),
                              timeout=0.0)
 
         self._robot.base.force_drive(-0.125, 0, 0, 1.5)
@@ -183,7 +180,7 @@ class Place(smach.StateMachine):
 
         #Check types or designator resolve types
         assert(item_to_place.resolve_type == Entity or type(item_to_place) == Entity)
-        assert(place_pose.resolve_type == (Frame, str) or type(place_pose) == (Frame, str))
+        assert(place_pose.resolve_type == FrameStamped or type(place_pose) == FrameStamped)
         assert(arm.resolve_type == Arm or type(arm) == Arm)
 
         with self:

--- a/robot_smach_states/src/robot_smach_states/manipulation/place.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/place.py
@@ -109,24 +109,24 @@ class Put(smach.State):
         arm.wait_for_motion_done()
 
         try:
-            height = place_pose_bl.z
+            height = place_pose_bl.frame.p.z()
         except KeyError:
             height = 0.8
 
         # Pre place
         if not arm.send_goal(place_pose_bl, timeout=10, pre_grasp=False):
             # If we can't place, try a little closer
-            place_pose_bl.frame.p.x(place_pose_bl.frame.p.x - 0.05)
+            place_pose_bl.frame.p.x(place_pose_bl.frame.p.x() - 0.05)
 
             rospy.loginfo("Retrying preplace")
-            if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.frame.p.x, place_pose_bl.frame.p.y, height+0.2, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
+            if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.frame.p.x(), place_pose_bl.frame.p.y(), height+0.2, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
                              timeout=10, pre_grasp=False):
                 rospy.logwarn("Cannot pre-place the object")
                 arm.cancel_goals()
                 return 'failed'
 
         # Place
-        if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.frame.p.x, place_pose_bl.frame.p.y, height+0.15, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
+        if not arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.frame.p.x(), place_pose_bl.frame.p.y(), height+0.15, 0.0, 0.0, 0.0, frame_id="/{0}/base_link".format(self._robot.robot_name)),
                              timeout=10, pre_grasp=False):
             rospy.logwarn("Cannot place the object, dropping it...")
 
@@ -144,7 +144,7 @@ class Put(smach.State):
         arm.occupied_by = None
 
         # Retract
-        arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.frame.p.x - 0.1, place_pose_bl.frame.p.y, place_pose_bl.frame.p.z + 0.05, 0.0, 0.0, 0.0, frame_id='/'+self._robot.robot_name+'/base_link'),
+        arm.send_goal(kdlFrameStampedFromXYZRPY(place_pose_bl.frame.p.x() - 0.1, place_pose_bl.frame.p.y(), place_pose_bl.frame.p.z() + 0.05, 0.0, 0.0, 0.0, frame_id='/'+self._robot.robot_name+'/base_link'),
                              timeout=0.0)
 
         self._robot.base.force_drive(-0.125, 0, 0, 1.5)

--- a/robot_smach_states/src/robot_smach_states/navigation/door_opening.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/door_opening.py
@@ -4,7 +4,7 @@ import rospy
 import smach
 import numpy as np
 from sensor_msgs.msg import LaserScan
-from geometry_msgs.msg import PolygonStamped, PointStamped, Point, PoseStamped, Pose
+from geometry_msgs.msg import PolygonStamped, Point, PoseStamped, Pose
 from threading import Event
 from visualization_msgs.msg import Marker, MarkerArray
 from cb_planner_msgs_srvs.msg import PositionConstraint

--- a/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
@@ -184,7 +184,7 @@ class FollowOperator(smach.State):
         just add it. '''
         if self._operator_id:
             if self._breadcrumbs:
-                if(self._breadcrumbs[-1]._pose - self._operator._pose).Norm() < self._breadcrumb_distance :
+                if self._breadcrumbs[-1].distance_to_2d(self._operator._pose.p) < self._breadcrumb_distance:
                     self._breadcrumbs[-1] = self._operator
                 else:
                     self._breadcrumbs.append(self._operator)
@@ -196,7 +196,7 @@ class FollowOperator(smach.State):
         # robot_yaw = transformations.euler_z_from_quaternion(self._robot.base.pose.orientation)
         temp_crumbs = []
         for crumb in self._breadcrumbs:
-            if (crumb - robot_position).Norm() > self._lookat_radius + 0.1:
+            if crumb.disntance_to_2d(robot_position.p) > self._lookat_radius + 0.1:
                 temp_crumbs.append(crumb)
             else:
                 temp_crumbs = []
@@ -257,12 +257,7 @@ class FollowOperator(smach.State):
             operator_pos.point.z = 0.0
             self._operator_pub.publish(operator_pos)
 
-            robot_position = self._robot.base.get_location().pose.position
-            operator_position = self._last_operator.pose.position
-
-            dx = operator_position.x - robot_position.x
-            dy = operator_position.y - robot_position.y
-            self._operator_distance = math.hypot(dx, dy)
+            self._operator_distance = (self._last_operator.distance_to_2d(self._robot.base.get_location().p))
 
             return True
         else:
@@ -281,22 +276,13 @@ class FollowOperator(smach.State):
                     operator_pos.point.z = 0.0
                     self._operator_pub.publish(operator_pos)
 
-                    robot_position = self._robot.base.get_location().pose.position
-                    operator_position = self._last_operator.pose.position
-
-                    dx = operator_position.x - robot_position.x
-                    dy = operator_position.y - robot_position.y
-                    self._operator_distance = math.hypot(dx, dy)
+                    self._operator_distance = (self._last_operator.distance_to_2d(self._robot.base.get_location().p))
 
                     return True
                 else:
                     self._robot.speech.speak("I'm sorry, but I couldn't find a person to track")
 
-            operator_position = self._last_operator.pose.position
-
-            dx = operator_position.x - robot_position.x
-            dy = operator_position.y - robot_position.y
-            self._operator_distance = math.hypot(dx, dy)
+            self._operator_distance = (self._last_operator.distance_to_2d(self._robot.base.get_location().p))
             # If the operator is lost, check if we still have an ID
             if self._operator_id:
                 # At the moment when the operator is lost, tell him to slow down and clear operator ID

--- a/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
@@ -569,7 +569,7 @@ class FollowOperator(smach.State):
         if self._operator_distance < self._operator_radius and self._operator_standing_still_for_x_seconds(self._operator_standing_still_timeout):
             print "I'm close enough to the operator and he's been standing there for long enough"
             print "Checking if we pass the start timeout"
-            if (self._robot.base.get_location().header.stamp - self._time_started).to_sec() > self._start_timeout:
+            if (rospy.Time.now() - self._time_started).to_sec() > self._start_timeout:
                 print "Passed"
                 self._operator_id_des.writeable.write(self._operator_id)
                 self._robot.base.local_planner.cancelCurrentPlan()

--- a/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
@@ -331,12 +331,12 @@ class FollowOperator(smach.State):
     def _update_navigation(self):
         self._robot.head.cancel_goal()
 
-        robot_position = self._robot.base.get_location().pose.position
-        operator_position = self._last_operator.pose.position
+        robot_position = self._robot.base.get_location().p
+        operator_position = self._last_operator._pose.p
 
         ''' Define end goal constraint, solely based on the (old) operator position '''
         p = PositionConstraint()
-        p.constraint = "(x-%f)^2 + (y-%f)^2 < %f^2"% (operator_position.x, operator_position.y, self._operator_radius)
+        p.constraint = "(x-%f)^2 + (y-%f)^2 < %f^2"% (operator_position.x(), operator_position.y(), self._operator_radius)
 
         o = OrientationConstraint()
         if self._operator_id:
@@ -358,7 +358,7 @@ class FollowOperator(smach.State):
             dx = crumb.pose.position.x - previous_point.x
             dy = crumb.pose.position.y - previous_point.y
 
-            length = math.hypot(dx, dy)
+            length = crumb.distance_to_2d(previous_point)
 
             if length != 0:
                 dx_norm = dx / length

--- a/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
@@ -8,6 +8,7 @@ import robot_smach_states as states
 import threading
 import time
 import itertools
+import PyKDL as kdl
 
 import math
 from visualization_msgs.msg import Marker
@@ -97,7 +98,7 @@ class FollowOperator(smach.State):
             last_yaw = self._last_pose_stamped.M.GetRPY()[2]  # Get the Yaw
 
             # Compare the pose with the last pose and update if difference is larger than x
-            if (current_pose_stamped - self._last_pose_stamped).Norm() > 0.05 or abs(current_yaw - last_yaw) > 0.3:
+            if kdl.diff(current_pose_stamped.p, self._last_pose_stamped.p).Norm() > 0.05 or abs(current_yaw - last_yaw) > 0.3:
                 # Update the last pose
           #      print "Last pose stamped (%f,%f) at %f secs"%(self._last_pose_stamped.pose.position.x, self._last_pose_stamped.pose.position.y, self._last_pose_stamped.header.stamp.secs)
                 self._last_pose_stamped = current_pose_stamped

--- a/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
@@ -16,7 +16,7 @@ from visualization_msgs.msg import Marker
 from cb_planner_msgs_srvs.msg import *
 
 from robot_skills.util import transformations, msg_constructors
-from robot_skills.util.kdl_conversions import kdlVectorStampedFromPointStampedMsg
+from robot_skills.util.kdl_conversions import VectorStamped
 
 
 class FollowOperator(smach.State):
@@ -410,16 +410,16 @@ class FollowOperator(smach.State):
                        -math.pi/6,
                        -math.pi/4,
                        -math.pi/2.3]
-        head_goals = [msg_constructors.PointStamped(x=look_distance*math.cos(angle),
-                                                    y=look_distance*math.sin(angle),
-                                                    z=1.7,
-                                                    frame_id="/%s/base_link" % self._robot.robot_name)
+        head_goals = [VectorStamped(x=look_distance*math.cos(angle),
+                                    y=look_distance*math.sin(angle),
+                                    z=1.7,
+                                    frame_id="/%s/base_link" % self._robot.robot_name)
                       for angle in look_angles
                       ]
 
         i = 0
         while (rospy.Time.now() - start_time).to_sec() < operator_recovery_timeout:
-            self._robot.head.look_at_point(kdlVectorStampedFromPointStampedMsg(head_goals[i]))
+            self._robot.head.look_at_point(head_goals[i])
             i += 1
             if i == len(head_goals):
                 i = 0

--- a/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
@@ -198,7 +198,7 @@ class FollowOperator(smach.State):
         # robot_yaw = transformations.euler_z_from_quaternion(self._robot.base.pose.orientation)
         temp_crumbs = []
         for crumb in self._breadcrumbs:
-            if crumb.disntance_to_2d(robot_position.p) > self._lookat_radius + 0.1:
+            if crumb.distance_to_2d(robot_position.p) > self._lookat_radius + 0.1:
                 temp_crumbs.append(crumb)
             else:
                 temp_crumbs = []

--- a/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
@@ -16,6 +16,7 @@ from visualization_msgs.msg import Marker
 from cb_planner_msgs_srvs.msg import *
 
 from robot_skills.util import transformations, msg_constructors
+from robot_skills.util.kdl_conversions import kdlVectorStampedFromPointStampedMsg
 
 
 class FollowOperator(smach.State):
@@ -418,7 +419,7 @@ class FollowOperator(smach.State):
 
         i = 0
         while (rospy.Time.now() - start_time).to_sec() < operator_recovery_timeout:
-            self._robot.head.look_at_point(head_goals[i])
+            self._robot.head.look_at_point(kdlVectorStampedFromPointStampedMsg(head_goals[i]))
             i += 1
             if i == len(head_goals):
                 i = 0

--- a/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
@@ -475,7 +475,7 @@ class FollowOperator(smach.State):
         return False
 
     def _turn_towards_operator(self):
-        robot_position = self._robot.base.get_location().pose.position
+        robot_position = self._robot.base.get_location().p
         operator_position = self._last_operator.pose.position
 
         p = PositionConstraint()

--- a/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/follow_operator.py
@@ -184,9 +184,7 @@ class FollowOperator(smach.State):
         just add it. '''
         if self._operator_id:
             if self._breadcrumbs:
-                dx = self._breadcrumbs[-1].pose.position.x - self._operator.pose.position.x
-                dy = self._breadcrumbs[-1].pose.position.y - self._operator.pose.position.y
-                if math.hypot(dx, dy) < self._breadcrumb_distance :
+                if(self._breadcrumbs[-1]._pose - self._operator._pose).Norm() < self._breadcrumb_distance :
                     self._breadcrumbs[-1] = self._operator
                 else:
                     self._breadcrumbs.append(self._operator)
@@ -194,13 +192,11 @@ class FollowOperator(smach.State):
                 self._breadcrumbs.append(self._operator)
 
         # Remove 'reached' breadcrumbs from breadcrumb path
-        robot_position = self._robot.base.get_location().pose.position
+        robot_position = self._robot.base.get_location()
         # robot_yaw = transformations.euler_z_from_quaternion(self._robot.base.pose.orientation)
         temp_crumbs = []
         for crumb in self._breadcrumbs:
-            dx = crumb.pose.position.x - robot_position.x
-            dy = crumb.pose.position.y - robot_position.y
-            if math.hypot(dx, dy) > self._lookat_radius + 0.1:
+            if (crumb - robot_position).Norm() > self._lookat_radius + 0.1:
                 temp_crumbs.append(crumb)
             else:
                 temp_crumbs = []

--- a/robot_smach_states/src/robot_smach_states/navigation/navigate_to_explore.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/navigate_to_explore.py
@@ -69,8 +69,8 @@ class NavigateToExplore(NavigateTo):
 
         # Loop over visited list
         for i in range(len(self.visited_list)):
-            xe = self.visited_list[i].pose.position.x
-            ye = self.visited_list[i].pose.position.y
+            xe = self.visited_list[i].p.x()
+            ye = self.visited_list[i].p.y()
             rospy.loginfo('xe = {0}, ye = {1}'.format(xe,ye))
 
             pci = pci + ' and '

--- a/robot_smach_states/src/robot_smach_states/navigation/navigate_to_place.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/navigate_to_place.py
@@ -5,7 +5,7 @@ from robot_smach_states.navigation import NavigateTo
 from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
-from PyKDL import Frame
+from robot_skills.util.kdl_conversions import FrameStamped
 
 from robot_smach_states.util.designators import Designator, check_resolve_type
 
@@ -24,7 +24,7 @@ class NavigateToPlace(NavigateTo):
         super(NavigateToPlace, self).__init__(robot)
 
         self.robot    = robot
-        check_resolve_type(place_pose_designator, (Frame, str)) #Check that place_pose_designator actually returns a PoseStamped
+        check_resolve_type(place_pose_designator, FrameStamped) #Check that place_pose_designator actually returns a PoseStamped
         self.place_pose_designator = place_pose_designator
 
         self.arm_designator = arm_designator
@@ -44,17 +44,17 @@ class NavigateToPlace(NavigateTo):
             angle_offset = math.atan2(self.robot.grasp_offset.y, self.robot.grasp_offset.x)
         radius = math.hypot(self.robot.grasp_offset.x, self.robot.grasp_offset.y)
 
-        place_pose, frame_id = self.place_pose_designator.resolve()
+        place_fs = self.place_pose_designator.resolve()
 
-        if not place_pose:
+        if not place_fs:
             rospy.logerr("No such place_pose")
             return None
 
-        rospy.loginfo("Navigating to place at {0}".format(place_pose).replace('\n', ' '))
+        rospy.loginfo("Navigating to place at {0}".format(place_fs).replace('\n', ' '))
 
         try:
-            x = place_pose.p.x()
-            y = place_pose.p.y()
+            x = place_fs.frame.p.x()
+            y = place_fs.frame.p.y()
         except KeyError, ke:
             rospy.logerr("Could not determine pose: ".format(ke))
             return None
@@ -64,7 +64,7 @@ class NavigateToPlace(NavigateTo):
         ri = "(x-%f)^2+(y-%f)^2 > %f^2"%(x, y, radius-0.075)
         # pc = PositionConstraint(constraint=ri+" and "+ro, frame="/map")
         # oc = OrientationConstraint(look_at=Point(x, y, 0.0), frame="/map", angle_offset=angle_offset)
-        pc = PositionConstraint(constraint=ri+" and "+ro, frame=frame_id)
-        oc = OrientationConstraint(look_at=Point(x, y, 0.0), frame=frame_id, angle_offset=angle_offset)
+        pc = PositionConstraint(constraint=ri+" and "+ro, frame=place_fs.frame_id)
+        oc = OrientationConstraint(look_at=Point(x, y, 0.0), frame=place_fs.frame_id, angle_offset=angle_offset)
 
         return pc, oc

--- a/robot_smach_states/src/robot_smach_states/navigation/navigate_to_place.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/navigate_to_place.py
@@ -5,6 +5,7 @@ from robot_smach_states.navigation import NavigateTo
 from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 from geometry_msgs.msg import *
+from PyKDL import Frame
 
 from robot_smach_states.util.designators import Designator, check_resolve_type
 
@@ -23,7 +24,7 @@ class NavigateToPlace(NavigateTo):
         super(NavigateToPlace, self).__init__(robot)
 
         self.robot    = robot
-        check_resolve_type(place_pose_designator, PoseStamped) #Check that place_pose_designator actually returns a PoseStamped
+        check_resolve_type(place_pose_designator, Frame) #Check that place_pose_designator actually returns a PoseStamped
         self.place_pose_designator = place_pose_designator
 
         self.arm_designator = arm_designator
@@ -52,8 +53,8 @@ class NavigateToPlace(NavigateTo):
         rospy.loginfo("Navigating to place at {0}".format(place_pose).replace('\n', ' '))
 
         try:
-            x = place_pose.pose.position.x
-            y = place_pose.pose.position.y
+            x = place_pose.p.x()
+            y = place_pose.p.y()
         except KeyError, ke:
             rospy.logerr("Could not determine pose: ".format(ke))
             return None

--- a/robot_smach_states/src/robot_smach_states/navigation/navigate_to_place.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/navigate_to_place.py
@@ -24,7 +24,7 @@ class NavigateToPlace(NavigateTo):
         super(NavigateToPlace, self).__init__(robot)
 
         self.robot    = robot
-        check_resolve_type(place_pose_designator, Frame) #Check that place_pose_designator actually returns a PoseStamped
+        check_resolve_type(place_pose_designator, (Frame, str)) #Check that place_pose_designator actually returns a PoseStamped
         self.place_pose_designator = place_pose_designator
 
         self.arm_designator = arm_designator
@@ -44,7 +44,7 @@ class NavigateToPlace(NavigateTo):
             angle_offset = math.atan2(self.robot.grasp_offset.y, self.robot.grasp_offset.x)
         radius = math.hypot(self.robot.grasp_offset.x, self.robot.grasp_offset.y)
 
-        place_pose = self.place_pose_designator.resolve()
+        place_pose, frame_id = self.place_pose_designator.resolve()
 
         if not place_pose:
             rospy.logerr("No such place_pose")
@@ -64,7 +64,7 @@ class NavigateToPlace(NavigateTo):
         ri = "(x-%f)^2+(y-%f)^2 > %f^2"%(x, y, radius-0.075)
         # pc = PositionConstraint(constraint=ri+" and "+ro, frame="/map")
         # oc = OrientationConstraint(look_at=Point(x, y, 0.0), frame="/map", angle_offset=angle_offset)
-        pc = PositionConstraint(constraint=ri+" and "+ro, frame=place_pose.header.frame_id)
-        oc = OrientationConstraint(look_at=Point(x, y, 0.0), frame=place_pose.header.frame_id, angle_offset=angle_offset)
+        pc = PositionConstraint(constraint=ri+" and "+ro, frame=frame_id)
+        oc = OrientationConstraint(look_at=Point(x, y, 0.0), frame=frame_id, angle_offset=angle_offset)
 
         return pc, oc

--- a/robot_smach_states/src/robot_smach_states/navigation/navigation.py
+++ b/robot_smach_states/src/robot_smach_states/navigation/navigation.py
@@ -9,6 +9,7 @@ import time
 
 from math import cos, sin
 from geometry_msgs.msg import *
+from robot_skills.util.kdl_conversions import kdlVectorStampedFromPointStampedMsg
 from cb_planner_msgs_srvs.srv import *
 from cb_planner_msgs_srvs.msg import *
 
@@ -192,7 +193,7 @@ class planBlocked(smach.State):
 
             # Look at the entity
             #ps = msgs.PointStamped(point=self.robot.base.local_planner.getObstaclePoint(), frame_id="/map")
-            #self.robot.head.look_at_point(ps)
+            #self.robot.head.look_at_point(kdlVectorStampedFromPointStampedMsg(ps))
 
 
             if not self.robot.base.local_planner.getStatus() == "blocked":

--- a/robot_smach_states/src/robot_smach_states/perception.py
+++ b/robot_smach_states/src/robot_smach_states/perception.py
@@ -3,9 +3,6 @@ import sys
 import rospy
 import smach
 
-from std_msgs.msg import Header
-from geometry_msgs.msg import Point, PointStamped
-
 from robot_smach_states.state import State
 import robot_smach_states.util.designators as ds
 from robot_skills.util.entity import Entity
@@ -59,7 +56,6 @@ class LookAtArea(State):
         #That would be equivalent to defining coordinates 0,0,0 in its own frame, so that is what we do here.
         #The added benefit is that the entity's frame actually moves because the entity is tracked.
         #This makes the head track the entity
-        center_point = Point()
         frame_id = "/"+entity.id
 
         if area in entity.volumes:

--- a/robot_smach_states/src/robot_smach_states/startup.py
+++ b/robot_smach_states/src/robot_smach_states/startup.py
@@ -18,7 +18,7 @@ from robot_smach_states.util.designators import Designator, VariableDesignator, 
 class StartChallengeRobust(smach.StateMachine):
     """Initialize, wait for the door to be opened and drive inside"""
 
-    def __init__(self, robot, initial_pose, use_entry_points = False):
+    def __init__(self, robot, initial_pose, use_entry_points = False, door=True):
         smach.StateMachine.__init__(self, outcomes=["Done", "Aborted", "Failed"])
         assert hasattr(robot, "base")
         assert hasattr(robot, "speech")
@@ -26,7 +26,7 @@ class StartChallengeRobust(smach.StateMachine):
         with self:
             smach.StateMachine.add( "INITIALIZE",
                                     utility.Initialize(robot),
-                                    transitions={   "initialized"   :"INSTRUCT_WAIT_FOR_DOOR",
+                                    transitions={   "initialized"   :"INSTRUCT_WAIT_FOR_DOOR" if door else "INIT_POSE",
                                                     "abort"         :"Aborted"})
 
             smach.StateMachine.add("INSTRUCT_WAIT_FOR_DOOR",
@@ -51,9 +51,9 @@ class StartChallengeRobust(smach.StateMachine):
             # since it is thinks amigo is standing in front of a wall if door is closed and localization can(/will) be messed up.
             smach.StateMachine.add('INIT_POSE',
                                 utility.SetInitialPose(robot, initial_pose),
-                                transitions={   'done':'ENTER_ROOM',
+                                transitions={   'done':'ENTER_ROOM' if door else "Done",
                                                 'preempted':'Aborted',  # This transition will never happen at the moment.
-                                                'error':'ENTER_ROOM'})  # It should never go to aborted.
+                                                'error':'ENTER_ROOM' if door else "Done"})  # It should never go to aborted.
 
             # Enter the arena with force drive as back-up
             smach.StateMachine.add('ENTER_ROOM',

--- a/robot_smach_states/src/robot_smach_states/startup.py
+++ b/robot_smach_states/src/robot_smach_states/startup.py
@@ -13,7 +13,7 @@ from sensor_msgs.msg import LaserScan
 from threading import Event
 
 import robot_skills.util.msg_constructors as msgs
-from robot_smach_states.util.designators import Designator, VariableDesignator, PointStampedOfEntityDesignator
+from robot_smach_states.util.designators import Designator, VariableDesignator
 
 class StartChallengeRobust(smach.StateMachine):
     """Initialize, wait for the door to be opened and drive inside"""

--- a/robot_smach_states/src/robot_smach_states/util/designators/core.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/core.py
@@ -55,7 +55,11 @@ class Designator(object):
         if isinstance(self.resolve_type, list):
             resolve_type = self.resolve_type[0]
 
-        if result is not None and not issubclass(result_type, resolve_type):
+        if isinstance(self.resolve_type, tuple):
+            result_types = map(type, result)
+            if not all(expected_type == resolved_type for expected_type, resolved_type in zip(self.resolve_type, result_types)):
+                raise TypeError("{} resolved to a '{}' instead of expected '{}'. ".format(self, result_types, resolve_type))
+        elif result is not None and not issubclass(result_type, resolve_type):
             raise TypeError("{} resolved to a '{}' instead of expected '{}'. "
                             "Originals: result type: {}, resolve type: {}".format(self, result_type, resolve_type,
                                                                                   type(result), self.resolve_type))

--- a/robot_smach_states/src/robot_smach_states/util/designators/core.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/core.py
@@ -55,11 +55,7 @@ class Designator(object):
         if isinstance(self.resolve_type, list):
             resolve_type = self.resolve_type[0]
 
-        if isinstance(self.resolve_type, tuple):
-            result_types = map(type, result)
-            if not all(expected_type == resolved_type for expected_type, resolved_type in zip(self.resolve_type, result_types)):
-                raise TypeError("{} resolved to a '{}' instead of expected '{}'. ".format(self, result_types, resolve_type))
-        elif result is not None and not issubclass(result_type, resolve_type):
+        if result is not None and not issubclass(result_type, resolve_type):
             raise TypeError("{} resolved to a '{}' instead of expected '{}'. "
                             "Originals: result type: {}, resolve type: {}".format(self, result_type, resolve_type,
                                                                                   type(result), self.resolve_type))

--- a/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
@@ -210,8 +210,16 @@ class EdEntityDesignator(Designator):
         entities = self.ed.get_entities(_type, _center_point, self.radius, _id, self.parse)
         if entities:
             for criterium in _criteria:
-                entities = filter(criterium, entities)
                 criterium_code = inspect.getsource(criterium)
+                filtered_entities = []
+                for entity in entities:
+                    try:
+                        if criterium(entity):
+                            filtered_entities += [entity]
+                    except Exception as exp:
+                        rospy.logerr("{id} cannot be filtered with criterum '{crit}': {exp}".format(id=entity.id, crit=criterium_code, exp=exp))
+
+                entities = filtered_entities
                 rospy.loginfo("Criterium {0} leaves {1} entities".format(criterium_code, len(entities)))
                 rospy.logdebug("Remaining entities: {}".format(pprint.pformat([ent.id for ent in entities])))
 

--- a/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
@@ -19,7 +19,7 @@ from robot_smach_states.util.designators.core import Designator
 from robot_smach_states.util.designators.checks import check_resolve_type
 
 from robot_smach_states.util.geometry_helpers import offsetConvexHull
-from robot_skills.util.kdl_conversions import poseMsgToKdlFrame, pointMsgToKdlVector
+from robot_skills.util.kdl_conversions import poseMsgToKdlFrame, pointMsgToKdlVector, VectorStamped
 import robot_smach_states.util.geometry_helpers as geom
 
 import robot_skills.util.msg_constructors as msg_constructors
@@ -136,7 +136,7 @@ class EdEntityDesignator(Designator):
         if center_point != None and center_point_designator != None:
             raise TypeError("Specify either center_point or center_point_designator, not both")
         elif center_point == None and center_point_designator == None:
-            center_point = gm.Point()
+            center_point = VectorStamped()
         if id != "" and id_designator != None:
             raise TypeError("Specify either id or id_designator, not both")
 
@@ -151,7 +151,7 @@ class EdEntityDesignator(Designator):
         if type_designator: check_resolve_type(type_designator, str, list) #the resolve type of type_designator can be either st or list
         self.type_designator = type_designator
 
-        if center_point_designator: check_resolve_type(center_point_designator, gm.PointStamped) #the resolve type of type_designator can be either st or list
+        if center_point_designator: check_resolve_type(center_point_designator, VectorStamped) #the resolve type of type_designator can be either st or list
         self.center_point_designator = center_point_designator
 
         if id_designator: check_resolve_type(id_designator, str)

--- a/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
@@ -424,7 +424,7 @@ class EmptySpotDesignator(Designator):
         :param center_pose: kdl.Frame, center pose of the Entity to place on top of
         :param z_max: float, height of the entity to place on, w.r.t. the entity
         :param convex_hull: [kdl.Vector], convex hull of the entity
-        :return: [geometry_msgs.msg.PointStamped] of candidates for placing
+        :return: [FrameStamped] of candidates for placing
         """
 
         points = []

--- a/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
@@ -27,31 +27,6 @@ import robot_skills.util.msg_constructors as msg_constructors
 
 __author__ = 'loy'
 
-class PointStampedOfEntityDesignator(Designator):
-    def __init__(self, entity_designator, name=None):
-        """Resolves to the PointStamped-part of the designated entity
-        :param entity_designator entity of which we want to know the position as a PointStamped
-        """
-        super(PointStampedOfEntityDesignator, self).__init__(resolve_type=gm.PointStamped, name=name)
-        self.entity_designator = entity_designator
-        self.ed = rospy.ServiceProxy('/ed/simple_query', SimpleQuery)
-
-    def _resolve(self):
-        # type is a reserved keyword. Maybe unpacking a dict as kwargs is
-        # cleaner
-        query = SimpleQueryRequest(id=self.entity_designator.resolve())
-        entities = self.ed(query).entities
-        if entities:
-            entity = entities[0]
-            pointstamped = gm.PointStamped(point=entity.pose.position,
-                                           header=std.Header(
-                                               entity.id, rospy.get_rostime())
-                                           )  # ID is also the frame ID. Ed just works that way
-            self._current = pointstamped
-            return self.current
-        else:
-            return None
-
 
 class EdEntityCollectionDesignator(Designator):
     """

--- a/robot_smach_states/src/robot_smach_states/utility.py
+++ b/robot_smach_states/src/robot_smach_states/utility.py
@@ -6,7 +6,6 @@ import smach
 import thread
 from visualization_msgs.msg import Marker
 
-import robot_skills.util.msg_constructors as msgs
 import std_msgs.msg
 from robot_skills.util import transformations as tf
 import robot_smach_states.util.designators as ds

--- a/robot_smach_states/src/robot_smach_states/world_model.py
+++ b/robot_smach_states/src/robot_smach_states/world_model.py
@@ -4,6 +4,7 @@ import rospy
 import smach
 
 import robot_skills.util.msg_constructors as msgs
+from robot_skills.util.kdl_conversions import VectorStamped
 
 from robot_smach_states.navigation import NavigateToObserve
 import robot_smach_states.util.designators as ds
@@ -37,11 +38,11 @@ class SegmentObjects(smach.State):
         self.segmented_entity_ids_designator = segmented_entity_ids_designator
 
     def _look_at_segmentation_area(self, entity):
-        look_at_point_z = 0.7
+        look_at_point_z = 0.7   # Where does this come from?
 
         # Make sure the head looks at the entity
         pos = entity.pose.position
-        self.robot.head.look_at_point(msgs.PointStamped(pos.x, pos.y, look_at_point_z, "/map"), timeout=0)
+        self.robot.head.look_at_point(VectorStamped(pos.x, pos.y, look_at_point_z, "/map"), timeout=0)
 
         # Check if we have areas
         if self.segmentation_area in entity.volumes:

--- a/robot_smach_states/src/robot_smach_states/world_model.py
+++ b/robot_smach_states/src/robot_smach_states/world_model.py
@@ -2,8 +2,6 @@
 
 import rospy
 import smach
-
-import robot_skills.util.msg_constructors as msgs
 from robot_skills.util.kdl_conversions import VectorStamped
 
 from robot_smach_states.navigation import NavigateToObserve

--- a/robot_smach_states/test/test_perception.py
+++ b/robot_smach_states/test/test_perception.py
@@ -4,7 +4,7 @@ import unittest
 
 # datatypes
 import PyKDL as kdl
-from geometry_msgs.msg import Point, PointStamped
+from robot_skills.util.kdl_conversions import VectorStamped
 
 #Robot Skills
 from robot_skills.mockbot import Mockbot
@@ -34,13 +34,9 @@ class TestLookAtEntity(unittest.TestCase):
 
         state.execute()
 
-        ps = PointStamped()
-        ps.header.frame_id = "/12345"  # The position of the entity is defined w.r.t. the map
-        ps.point.x = 0
-        ps.point.y = 0
-        ps.point.z = 0
+        vs = VectorStamped(0, 0, 0, "/12345")
 
-        self.robot.head.look_at_point.assert_called_with(ps)
+        self.robot.head.look_at_point.assert_called_with(vs)
 
 
 class TestLookAtArea(unittest.TestCase):
@@ -66,13 +62,9 @@ class TestLookAtArea(unittest.TestCase):
 
         state.execute()
 
-        ps = PointStamped()
-        ps.header.frame_id = "/12345"  # The ID
-        ps.point.x = 0.5
-        ps.point.y = 0.5
-        ps.point.z = 0.5
+        vs = VectorStamped(0.5, 0.5, 0.5, "/12345")
 
-        self.robot.head.look_at_point.assert_called_with(ps, timeout=0)
+        self.robot.head.look_at_point.assert_called_with(vs, timeout=0)
 
 class TestLookOnTopOfEntity(unittest.TestCase):
     def setUp(self):
@@ -95,13 +87,12 @@ class TestLookOnTopOfEntity(unittest.TestCase):
 
         state.execute()
 
-        ps = PointStamped()
-        ps.header.frame_id = "/12345"  # The ID
-        ps.point.x = 0
-        ps.point.y = 0
-        ps.point.z = 1  # This is the height of the object, as indicated by the z_max
+        vs = VectorStamped(0,
+                           0,
+                           1,         # This is the height of the object, as indicated by the z_max
+                           "/12345")  # The ID
 
-        self.robot.head.look_at_point.assert_called_with(ps)
+        self.robot.head.look_at_point.assert_called_with(vs)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Addresses #156

This allows to perform calculations with the geometric datatypes directly and allows to reduce geometric calc. code all around.

As opposed to https://github.com/tue-robotics/tue_robocup/pull/162, this PR does merge into the correct branch: refactor/cleanup_and_merge