### PR TITLE
feature(Motion clients) Actions are cancelled if not reached in time

### DIFF
--- a/robot_skills/src/robot_skills/arms.py
+++ b/robot_skills/src/robot_skills/arms.py
@@ -216,6 +216,15 @@ class Arm(RobotPart):
                 execute_timeout=rospy.Duration(timeout)
             )
             if result == GoalStatus.SUCCEEDED:
+                
+                result_pose = self.tf_listener.lookupTransform("amigo/base_link", "amigo/grippoint_{}".format(self.side))
+                dx = grasp_precompute_goal.goal.x - result_pose[0][0]
+                dy = grasp_precompute_goal.goal.y - result_pose[0][1]
+                dz = grasp_precompute_goal.goal.z - result_pose[0][2]
+                
+                if abs(dx) > 0.005 or abs(dy) > 0.005 or abs(dz) > 0.005:
+                    rospy.logwarn("Grasp-precompute error too large: [{}, {}, {}]".format(
+                                  dx, dy, dz))
                 return True
             else:
                 # failure
@@ -361,7 +370,6 @@ class Arm(RobotPart):
             if len(joints_reference) != len(joint_names):
                 rospy.logwarn('Please use the correct %d number of joint references (current = %d'
                               % (len(joint_names), len(joints_references)))
-
             ps.append(JointTrajectoryPoint(
                 positions=joints_reference,
                 time_from_start=time_from_start))
@@ -389,11 +397,21 @@ class Arm(RobotPart):
         else:
             return None
 
-    def wait_for_motion_done(self, timeout=10.0):
+    def wait_for_motion_done(self, timeout=10.0, cancel=False):
+        """ Waits until all action clients are done
+        :param timeout: double with time (defaults to 10.0 seconds)
+        :param cancel: bool specifying whether goals should be cancelled
+        if timeout is exceeded
+        :return bool indicates whether motion was done (True if reached,
+        False otherwise)
+        """
         # rospy.loginfo('Waiting for ac_joint_traj')
         starttime = rospy.Time.now()
         if self._ac_joint_traj.gh:
-            self._ac_joint_traj.wait_for_result(rospy.Duration(10.0))
+            if not self._ac_joint_traj.wait_for_result(rospy.Duration(10.0)):
+                if cancel:
+                    rospy.loginfo("Arms: cancelling all goals (1)")
+                    self.cancel_goals()
 
         passed_time = (rospy.Time.now() - starttime).to_sec()
         if passed_time > timeout:
@@ -401,7 +419,10 @@ class Arm(RobotPart):
 
         # rospy.loginfo('Waiting for ac_grasp_precompute')
         if self._ac_grasp_precompute.gh:
-            self._ac_grasp_precompute.wait_for_result(rospy.Duration(timeout-passed_time))
+            if not self._ac_grasp_precompute.wait_for_result(rospy.Duration(timeout-passed_time)):
+                if cancel:
+                    rospy.loginfo("Arms: cancelling all goals (2)")
+                    self.cancel_goals()
 
         passed_time = (rospy.Time.now() - starttime).to_sec()
         if passed_time > timeout:
@@ -409,7 +430,7 @@ class Arm(RobotPart):
 
         # rospy.loginfo('Waiting for ac_gripper')
         if self._ac_gripper.gh:
-            rospy.logwarn('Not waiting for gripper action')
+            rospy.logdebug('Not waiting for gripper action')
             return True
             return self._ac_gripper.wait_for_result(rospy.Duration(timeout-passed_time))
 

--- a/robot_skills/src/robot_skills/torso.py
+++ b/robot_skills/src/robot_skills/torso.py
@@ -105,7 +105,14 @@ class Torso(RobotPart):
         self.ac_move_torso.cancel_goal()
         #return True
 
-    def wait_for_motion_done(self, timeout=10):
+    def wait_for_motion_done(self, timeout=10, cancel=False):
+        """ Waits until all action clients are done
+        :param timeout: double with time (defaults to 10.0 seconds)
+        :param cancel: bool specifying whether goals should be cancelled
+        if timeout is exceeded
+        :return bool indicates whether motion was done (True if reached,
+        False otherwise)
+        """
         if self.ac_move_torso.gh:
             self.ac_move_torso.wait_for_result(rospy.Duration(timeout))
             if self.ac_move_torso.get_state() == GoalStatus.SUCCEEDED:
@@ -113,6 +120,9 @@ class Torso(RobotPart):
                 return True
             else:
                 rospy.logerr("Reaching torso target failed")
+                if cancel:
+                    rospy.loginfo("Torso: cancelling all goals (1)")
+                    self.cancel_goal()
                 return False
 
     def wait(self, timeout=10):

--- a/robot_smach_states/src/robot_smach_states/manipulation/grab.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/grab.py
@@ -108,8 +108,8 @@ class PickUp(smach.State):
             return 'failed'
 
         # Make sure the torso and the arm are done
-        self.robot.torso.wait_for_motion_done()
-        arm.wait_for_motion_done()
+        self.robot.torso.wait_for_motion_done(cancel=True)
+        arm.wait_for_motion_done(cancel=True)
 
         # This is needed because the head is not entirely still when the
         # look_at_point function finishes
@@ -175,7 +175,7 @@ class PickUp(smach.State):
         #     return 'failed'
 
         # Grasp
-        # rospy.loginfo('Start grasping')
+        rospy.loginfo('Start grasping')
         if not arm.send_goal(goal_bl,
                              timeout=20, pre_grasp=True,
                              allowed_touch_objects=[grab_entity.id]
@@ -200,6 +200,7 @@ class PickUp(smach.State):
 
         goal_bl.frame.p.z(goal_bl.frame.p.z() + 0.05)  # Add 5 cm
         goal_bl.frame.M = kdl.Rotation.RPY(roll, 0, 0)  # Update the roll
+        rospy.loginfo("Start lift")
         if not arm.send_goal(goal_bl, timeout=20, allowed_touch_objects=[grab_entity.id]):
             rospy.logerr('Failed lift')
 
@@ -213,6 +214,7 @@ class PickUp(smach.State):
         goal_bl.frame.p.x(goal_bl.frame.p.x() -0.1)  # Retract 10 cm
         goal_bl.frame.p.z(goal_bl.frame.p.z() + 0.05)  # Go 5 cm higher
         goal_bl.frame.M = kdl.Rotation.RPY(roll, 0.0, 0.0)  # Update the roll
+        rospy.loginfo("Start retract")
         if not arm.send_goal(goal_bl, timeout=0.0, allowed_touch_objects=[grab_entity.id]):
             rospy.logerr('Failed retract')
 
@@ -221,7 +223,7 @@ class PickUp(smach.State):
         # Update Kinect once again to make sure the object disappears from ED
         segm_res = self.robot.ed.update_kinect("%s" % grab_entity.id)
 
-        arm.wait_for_motion_done()
+        arm.wait_for_motion_done(cancel=True)
 
         # Carrying pose
         # rospy.loginfo('start moving to carrying pose')


### PR DESCRIPTION
If timeouts exceeded in the wait_for_motion_done of the arms and
torso, all action goals are cancelled (if the parameter 'cancel'
is set to True)