### PR TITLE
fix(world_model_ed): get closest entity vector default

### DIFF
--- a/robot_skills/src/robot_skills/world_model_ed.py
+++ b/robot_skills/src/robot_skills/world_model_ed.py
@@ -95,7 +95,10 @@ class ED(RobotPart):
 
         return entities
 
-    def get_closest_entity(self, type="", center_point=VectorStamped(), radius=0):
+    def get_closest_entity(self, type="", center_point=None, radius=0):
+        if not center_point:
+            center_point = VectorStamped(x=0, y=0, z=0, frame_id="/"+self.robot_name+"/base_link")
+
         entities = self.get_entities(type=type, center_point=center_point, radius=radius)
 
         # HACK


### PR DESCRIPTION
Now defaults to 0,0,0 in /<robot_name>/base_link, which makes more sense from the user's perspective (when do you ever want the closest room to (some point in) the /map frame?)