### PR TITLE
fix(Api) Timeout is passed to HMI server

### DIFF
--- a/robot_skills/src/robot_skills/api.py
+++ b/robot_skills/src/robot_skills/api.py
@@ -17,7 +17,7 @@ class Api(RobotPart):
         """
         Perform a HMI query, returns a HMIResult
         """
-        return self._client.query(description, grammar, target)
+        return self._client.query(description, grammar, target, timeout)
 
     @property
     def last_talker_id(self):


### PR DESCRIPTION
Timeout bug is fixed. In general, I still think the class name Api is extremely confusing: this could be an API to anything, not just HMI.

Most important thing to fix this first though ;)