### PR TITLE
Remove default robot name in robot_constructor

### DIFF
--- a/robot_skills/src/robot_skills/util/robot_constructor.py
+++ b/robot_skills/src/robot_skills/util/robot_constructor.py
@@ -1,9 +1,7 @@
 import sys
 
-def robot_constructor(robot_name=None):
+def robot_constructor(robot_name):
     """Construct a robot by it's name. Choices are amigo, sergio, mockbot"""
-    if not robot_name:
-        robot_name = sys.argv[1]
 
     if robot_name == "amigo":
         import robot_skills.amigo

--- a/robot_skills/src/robot_skills/util/robot_constructor.py
+++ b/robot_skills/src/robot_skills/util/robot_constructor.py
@@ -1,7 +1,9 @@
 import sys
 
 def robot_constructor(robot_name):
-    """Construct a robot by it's name. Choices are amigo, sergio, mockbot"""
+    """Construct a robot by it's name. Choices are amigo, sergio, mockbot
+    :param robot_name str of robot name. Current options are amigo, sergio, mockbot
+    :returns a Robot-instance"""
 
     if robot_name == "amigo":
         import robot_skills.amigo


### PR DESCRIPTION
The argument is supplied in all use-cases according to ack-grep  --follow --python 'robot_constructor'