### PR TITLE
changed hardcoded grasp_offset to be loaded from parameters

### DIFF
--- a/robot_skills/src/robot_skills/robot.py
+++ b/robot_skills/src/robot_skills/robot.py
@@ -81,8 +81,8 @@ class Robot(object):
         self._hardware_status_sub = rospy.Subscriber("/" + self.robot_name + "/hardware_status", DiagnosticArray, self.handle_hardware_status)
 
         # Grasp offsets
-        go = self.load_param('skills/arm/offset/grasp_offset')
-        self.grasp_offset = geometry_msgs.msg.Point(go.x, go.y, go.z)
+        go = rospy.get_param('skills/arm/offset/grasp_offset')
+        self.grasp_offset = geometry_msgs.msg.Point(go.get("x"), go.get("y"), go.get("z"))
 
         # Create attributes from dict
         for partname, bodypart in self.parts.iteritems():

--- a/robot_skills/src/robot_skills/robot.py
+++ b/robot_skills/src/robot_skills/robot.py
@@ -81,8 +81,8 @@ class Robot(object):
         self._hardware_status_sub = rospy.Subscriber("/" + self.robot_name + "/hardware_status", DiagnosticArray, self.handle_hardware_status)
 
         # Grasp offsets
-        #TODO: Don't hardcode, load from parameter server to make robot independent.
-        self.grasp_offset = geometry_msgs.msg.Point(0.5, 0.2, 0.0)
+        go = self.load_param('skills/arm/offset/grasp_offset')
+        self.grasp_offset = geometry_msgs.msg.Point(go.x, go.y, go.z)
 
         # Create attributes from dict
         for partname, bodypart in self.parts.iteritems():

--- a/robot_skills/src/robot_skills/robot.py
+++ b/robot_skills/src/robot_skills/robot.py
@@ -81,7 +81,7 @@ class Robot(object):
         self._hardware_status_sub = rospy.Subscriber("/" + self.robot_name + "/hardware_status", DiagnosticArray, self.handle_hardware_status)
 
         # Grasp offsets
-        go = rospy.get_param('skills/arm/offset/grasp_offset')
+        go = rospy.get_param("/"+self.robot_name+"/skills/arm/offset/grasp_offset")
         self.grasp_offset = geometry_msgs.msg.Point(go.get("x"), go.get("y"), go.get("z"))
 
         # Create attributes from dict


### PR DESCRIPTION
Robot.py loads the parameters from the grasp offset from the robot description. I think this is a clean solution, since these values are robot-specific. This fixes issue #626. This PR goes together with PR 8 in sergio_description and 21 in amigo_description. 