### PR TITLE
Use Robot.arms as a dictionary, not as a list

### DIFF
--- a/robot_smach_states/src/robot_smach_states/util/designators/arm.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/arm.py
@@ -56,7 +56,7 @@ class UnoccupiedArmDesignator(ArmDesignator):
     >>> robot.arms['right'].occupied_by = None
     >>> empty_arm_designator = UnoccupiedArmDesignator(robot, {})
     >>> arm_to_use_for_first_grab = empty_arm_designator.resolve()
-    >>> assert arm_to_use_for_first_grab._arm in robot.arms.keys()
+    >>> assert arm_to_use_for_first_grab._arm in robot.arms.values()
     >>>
     >>> # Grab the 1st item.
     >>> arm_to_use_for_first_grab.occupied_by = "entity1"

--- a/robot_smach_states/src/robot_smach_states/util/designators/arm.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/arm.py
@@ -56,7 +56,7 @@ class UnoccupiedArmDesignator(ArmDesignator):
     >>> robot.arms['right'].occupied_by = None
     >>> empty_arm_designator = UnoccupiedArmDesignator(robot, {})
     >>> arm_to_use_for_first_grab = empty_arm_designator.resolve()
-    >>> assert arm_to_use_for_first_grab._arm in robot.arms
+    >>> assert arm_to_use_for_first_grab._arm in robot.arms.keys()
     >>>
     >>> # Grab the 1st item.
     >>> arm_to_use_for_first_grab.occupied_by = "entity1"


### PR DESCRIPTION
As per https://dev.azure.com/tue-robotics/tue-robotics/_build/results?buildId=408&view=logs&j=3588f332-17ad-5040-588c-7fa8695f6360&t=8a06a9b9-6f5b-50f7-18c3-72900e299def&l=315

The build error there is 
```
2019-10-01T22:52:52.7041098Z ************************
2019-10-01T22:52:52.7041208Z File "/home/amigo/ros/kinetic/system/src/robot_smach_states/src/robot_smach_states/util/designators/arm.py", line 59, in robot_smach_states.util.designators.arm.UnoccupiedArmDesignator
2019-10-01T22:52:52.7041307Z Failed example:
2019-10-01T22:52:52.7041377Z     assert arm_to_use_for_first_grab._arm in robot.arms
2019-10-01T22:52:52.7041433Z Exception raised:
2019-10-01T22:52:52.7041499Z     Traceback (most recent call last):
2019-10-01T22:52:52.7041561Z       File "/usr/lib/python2.7/doctest.py", line 1315, in __run
2019-10-01T22:52:52.7041635Z         compileflags, 1) in test.globs
2019-10-01T22:52:52.7041703Z       File "<doctest robot_smach_states.util.designators.arm.UnoccupiedArmDesignator[6]>", line 1, in <module>
2019-10-01T22:52:52.7041794Z         assert arm_to_use_for_first_grab._arm in robot.arms
2019-10-01T22:52:52.7041851Z     AssertionError
2019-10-01T22:52:52.7041924Z ************************
``` occurring in 
https://github.com/tue-robotics/tue_robocup/blob/rwc2019_robot_smach_states/robot_smach_states/src/robot_smach_states/util/designators/arm.py#L59

robot.arms is a dictionary (because of the useage of robot.arms['left']). 
Line 59 is `assert arm_to_use_for_first_grab._arm in robot.arms` and ..._arm is an Arm object while while the `in` is into a  `Dict[str, PublicArm]`. So instead I think it should be `arm_to_use_for_first_grab._arm in robot.arms.values()`.