### PR TITLE
Fix base class initialization of RandomNavDesignator

### DIFF
--- a/robot_smach_states/examples/navigation/example_random_nav2.py
+++ b/robot_smach_states/examples/navigation/example_random_nav2.py
@@ -17,10 +17,10 @@ from robot_smach_states.designators.designator import Designator
 from ed_msgs.srv import SimpleQuery
 
 
-class RandomNavDesignator(Designator):
+class RandomNavDesignator(EdEntityDesignator):
 
     def __init__(self, robot):
-        super(Designator, self).__init__()
+        super(RandomNavDesignator, self).__init__()
         self._robot = robot
         self.entity_id = None
         self.last_entity_id = None


### PR DESCRIPTION
Initializing the base class of the base class looks wrong.

Fixing it in the normal way (ie only change `super(RandomNavDesignator, ...)` breaks, as `Designator does not allow being initialized without arguments.

Tracing its use in the same file:
```
173: self.random_nav_designator = RandomNavDesignator(self.robot)
221: states.NavigateToObserve(robot, self.random_nav_designator),
```
In `NavigateToObserve`:
```
17: def __init__(self, robot, entity_designator, radius=0.7, margin=0.075):
21: :param entity_designator: EdEntityDesignator for the object to observe
```
That class allows an empty contructor as well.