### PR TITLE
fixed imports of Emptyspotdesignator

### DIFF
--- a/challenge_help_me_carry/src/challenge_help_me_carry.py
+++ b/challenge_help_me_carry/src/challenge_help_me_carry.py
@@ -5,6 +5,7 @@ import smach
 import datetime
 import robot_smach_states as states
 import robot_smach_states.util.designators as ds
+from robot_smach_states.manipulation.place_designator import EmptySpotDesignator
 
 from robot_skills.arms import GripperState
 from robocup_knowledge import load_knowledge
@@ -27,11 +28,6 @@ class ChallengeHelpMeCarry(smach.StateMachine):
 
         self.car_waypoint = ds.EntityByIdDesignator(robot, id=challenge_knowledge.waypoint_car['id'])
 
-        self.place_position = ds.LockingDesignator(ds.EmptySpotDesignator(robot, self.target_destination,
-                                                                          name="placement",
-                                                                          area=challenge_knowledge.default_area),
-                                                   name="place_position")
-
         self.empty_arm_designator = ds.UnoccupiedArmDesignator(robot, {}, name="empty_arm_designator")
 
         # With the empty_arm_designator locked, it will ALWAYS resolve to the same arm, unless it is unlocked.
@@ -39,6 +35,14 @@ class ChallengeHelpMeCarry(smach.StateMachine):
 
         self.bag_arm_designator = self.empty_arm_designator.lockable()
         self.bag_arm_designator.lock()
+
+        self.place_position = ds.LockingDesignator(EmptySpotDesignator(robot, self.target_destination,
+                                                                          arm_designator=self.bag_arm_designator,
+                                                                          name="placement",
+                                                                          area=challenge_knowledge.default_area),
+                                                   name="place_position")
+
+
 
         # We don't actually grab something, so there is no need for an actual thing to grab
 

--- a/challenge_help_me_carry/src/challenge_help_me_carry2.py
+++ b/challenge_help_me_carry/src/challenge_help_me_carry2.py
@@ -5,6 +5,7 @@ import smach
 import datetime
 import robot_smach_states as states
 import robot_smach_states.util.designators as ds
+from robot_smach_states.manipulation.place_designator import EmptySpotDesignator
 
 from robot_skills.arms import GripperState
 from robocup_knowledge import load_knowledge
@@ -27,11 +28,6 @@ class ChallengeHelpMeCarry(smach.StateMachine):
 
         self.car_waypoint = ds.EntityByIdDesignator(robot, id=challenge_knowledge.waypoint_car['id'])
 
-        self.place_position = ds.LockingDesignator(ds.EmptySpotDesignator(robot, self.target_destination,
-                                                                          name="placement",
-                                                                          area=challenge_knowledge.default_area),
-                                                   name="place_position")
-
         self.empty_arm_designator = ds.UnoccupiedArmDesignator(robot, {}, name="empty_arm_designator")
 
         # With the empty_arm_designator locked, it will ALWAYS resolve to the same arm, unless it is unlocked.
@@ -40,6 +36,11 @@ class ChallengeHelpMeCarry(smach.StateMachine):
         self.bag_arm_designator = self.empty_arm_designator.lockable()
         self.bag_arm_designator.lock()
 
+        self.place_position = ds.LockingDesignator(EmptySpotDesignator(robot, self.target_destination,
+                                                                       arm_designator=self.bag_arm_designator,
+                                                                       name="placement",
+                                                                       area=challenge_knowledge.default_area),
+                                                   name="place_position")
         # We don't actually grab something, so there is no need for an actual thing to grab
 
         self.current_item = ds.VariableDesignator(Entity("dummy", "dummy", "/{}/base_link".format(robot.robot_name),

--- a/challenge_set_a_table/src/challenge_set_a_table_states/clear_manipulate_machine.py
+++ b/challenge_set_a_table/src/challenge_set_a_table_states/clear_manipulate_machine.py
@@ -6,6 +6,7 @@ import smach
 import robot_skills
 import robot_smach_states as states
 import robot_smach_states.util.designators as ds
+from robot_smach_states.manipulation.place_designator import EmptySpotDesignator
 
 # Challenge set the table
 # from entity_description_designator import EntityDescriptionDesignator
@@ -48,16 +49,16 @@ class ClearManipulateMachine(smach.StateMachine):
         arm_designator = ds.UnoccupiedArmDesignator(robot, {})
 
         place_furniture_designator1 = ds.EntityByIdDesignator(robot, id=place_furniture_id1)
-        place_designator1 = ds.EmptySpotDesignator(robot=robot,
-                                                   place_location_designator=place_furniture_designator1,
-                                                   arm_designator=arm_designator,
-                                                   area="on_top_of")
+        place_designator1 = EmptySpotDesignator(robot=robot,
+                                                place_location_designator=place_furniture_designator1,
+                                                arm_designator=arm_designator,
+                                                area="on_top_of")
 
         place_furniture_designator3 = ds.EntityByIdDesignator(robot, id=place_furniture_id2)
-        place_designator3 = ds.EmptySpotDesignator(robot=robot,
-                                                   place_location_designator=place_furniture_designator3,
-                                                   arm_designator=arm_designator,
-                                                   area="on_top_of")
+        place_designator3 = EmptySpotDesignator(robot=robot,
+                                                place_location_designator=place_furniture_designator3,
+                                                arm_designator=arm_designator,
+                                                area="on_top_of")
 
         with self:
 

--- a/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
+++ b/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
@@ -75,7 +75,7 @@ class GrabSingleItem(smach.StateMachine):
         smach.StateMachine.__init__(self, outcomes=["succeeded", "failed"])
 
         # Create designators
-        self.empty_arm_designator = ds.ArmDesignator(robot, {}, name="empty_arm_designator")
+        self.empty_arm_designator = ds.UnoccupiedArmDesignator(robot, {}, name="empty_arm_designator")
         self.grab_designator = ds.LockToId(robot=robot, to_be_locked=grab_designator)
 
         with self:

--- a/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
+++ b/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
@@ -179,7 +179,7 @@ class ManipulateMachine(smach.StateMachine):
         grasp_furniture_designator2 = ds.EntityByIdDesignator(robot, id=grasp_furniture_id2)
 
         place_furniture_designator = ds.EntityByIdDesignator(robot, id=place_furniture_id)
-        arm_designator = ds.OccupiedArmDesignator(robot, {})
+        arm_designator = ds.ArmDesignator(robot, {})
         place_designator = EmptySpotDesignator(robot=robot,
                                                place_location_designator=place_furniture_designator,
                                                arm_designator=arm_designator,

--- a/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
+++ b/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
@@ -75,7 +75,7 @@ class GrabSingleItem(smach.StateMachine):
         smach.StateMachine.__init__(self, outcomes=["succeeded", "failed"])
 
         # Create designators
-        self.empty_arm_designator = ds.UnoccupiedArmDesignator(robot, {}, name="empty_arm_designator")
+        self.empty_arm_designator = ds.ArmDesignator(robot, {}, name="empty_arm_designator")
         self.grab_designator = ds.LockToId(robot=robot, to_be_locked=grab_designator)
 
         with self:

--- a/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
+++ b/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
@@ -6,6 +6,7 @@ import smach
 import robot_skills
 import robot_smach_states as states
 import robot_smach_states.util.designators as ds
+from robot_smach_states.manipulation.place_designator import EmptySpotDesignator
 
 # Challenge set the table
 from config import MIN_GRAB_OBJECT_HEIGHT, MAX_GRAB_OBJECT_WIDTH
@@ -178,9 +179,11 @@ class ManipulateMachine(smach.StateMachine):
         grasp_furniture_designator2 = ds.EntityByIdDesignator(robot, id=grasp_furniture_id2)
 
         place_furniture_designator = ds.EntityByIdDesignator(robot, id=place_furniture_id)
-        place_designator = ds.EmptySpotDesignator(robot=robot,
-                                                  place_location_designator=place_furniture_designator,
-                                                  area="on_top_of")
+        arm_designator = ds.UnoccupiedArmDesignator(robot, {})
+        place_designator = EmptySpotDesignator(robot=robot,
+                                               place_location_designator=place_furniture_designator,
+                                               arm_designator=arm_designator,
+                                               area="on_top_of")
 
         with self:
 

--- a/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
+++ b/challenge_set_a_table/src/challenge_set_a_table_states/manipulate_machine.py
@@ -179,7 +179,7 @@ class ManipulateMachine(smach.StateMachine):
         grasp_furniture_designator2 = ds.EntityByIdDesignator(robot, id=grasp_furniture_id2)
 
         place_furniture_designator = ds.EntityByIdDesignator(robot, id=place_furniture_id)
-        arm_designator = ds.UnoccupiedArmDesignator(robot, {})
+        arm_designator = ds.OccupiedArmDesignator(robot, {})
         place_designator = EmptySpotDesignator(robot=robot,
                                                place_location_designator=place_furniture_designator,
                                                arm_designator=arm_designator,

--- a/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
+++ b/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
@@ -206,7 +206,7 @@ class ManipulateMachine(smach.StateMachine):
         self.cabinet = ds.EntityByIdDesignator(robot, id="temp")  # will be updated later on
 
         self.place_entity_designator = ds.EdEntityDesignator(robot=robot, id="temp")
-        self.arm_designator = ds.ArmDesignator(robot, {})
+        self.arm_designator = ds.UnoccupiedArmDesignator(robot, {})
         self.place_designator = EmptySpotDesignator(robot=robot,
                                                     place_location_designator=self.place_entity_designator,
                                                     arm_designator=self.arm_designator,

--- a/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
+++ b/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
@@ -206,7 +206,7 @@ class ManipulateMachine(smach.StateMachine):
         self.cabinet = ds.EntityByIdDesignator(robot, id="temp")  # will be updated later on
 
         self.place_entity_designator = ds.EdEntityDesignator(robot=robot, id="temp")
-        self.arm_designator = ds.UnoccupiedArmDesignator(robot, {})
+        self.arm_designator = ds.ArmDesignator(robot, {})
         self.place_designator = EmptySpotDesignator(robot=robot,
                                                     place_location_designator=self.place_entity_designator,
                                                     arm_designator=self.arm_designator,

--- a/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
+++ b/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
@@ -83,7 +83,7 @@ class GrabSingleItem(smach.StateMachine):
         smach.StateMachine.__init__(self, outcomes=["succeeded", "failed"])
 
         # Create designators
-        self.empty_arm_designator = ds.OccupiedArmDesignator(robot, {}, name="empty_arm_designator")
+        self.empty_arm_designator = ds.UnoccupiedArmDesignator(robot, {}, name="empty_arm_designator")
         self.grab_designator = ds.LockToId(robot=robot, to_be_locked=grab_designator)
 
         with self:

--- a/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
+++ b/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
@@ -83,7 +83,7 @@ class GrabSingleItem(smach.StateMachine):
         smach.StateMachine.__init__(self, outcomes=["succeeded", "failed"])
 
         # Create designators
-        self.empty_arm_designator = ds.UnoccupiedArmDesignator(robot, {}, name="empty_arm_designator")
+        self.empty_arm_designator = ds.OccupiedArmDesignator(robot, {}, name="empty_arm_designator")
         self.grab_designator = ds.LockToId(robot=robot, to_be_locked=grab_designator)
 
         with self:

--- a/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
+++ b/challenge_storing_groceries/src/challenge_storing_groceries/manipulate_machine.py
@@ -6,6 +6,7 @@ import smach
 import robot_skills
 import robot_smach_states as states
 import robot_smach_states.util.designators as ds
+from robot_smach_states.manipulation.place_designator import EmptySpotDesignator
 
 # Challenge storing groceries
 from entity_description_designator import EntityDescriptionDesignator
@@ -205,9 +206,11 @@ class ManipulateMachine(smach.StateMachine):
         self.cabinet = ds.EntityByIdDesignator(robot, id="temp")  # will be updated later on
 
         self.place_entity_designator = ds.EdEntityDesignator(robot=robot, id="temp")
-        self.place_designator = ds.EmptySpotDesignator(robot=robot,
-                                                       place_location_designator=self.place_entity_designator,
-                                                       area="temp")
+        self.arm_designator = ds.UnoccupiedArmDesignator(robot, {})
+        self.place_designator = EmptySpotDesignator(robot=robot,
+                                                    place_location_designator=self.place_entity_designator,
+                                                    arm_designator=self.arm_designator,
+                                                    area="temp")
         self.placeaction1 = PlaceSingleItem(robot=robot, place_designator=self.place_designator)
         self.placeaction2 = PlaceSingleItem(robot=robot, place_designator=self.place_designator)
 

--- a/challenge_take_out_the_garbage/src/challenge_take_out_the_garbage/pick_up.py
+++ b/challenge_take_out_the_garbage/src/challenge_take_out_the_garbage/pick_up.py
@@ -10,7 +10,7 @@ from smach import cb_interface, CBState
 import robot_smach_states as states
 import robot_smach_states.manipulation as manipulation
 from robot_skills.arms import PublicArm
-import robot_smach_states.util.designators as ds
+from robot_smach_states.manipulation.place_designator import EmptySpotDesignator
 from challenge_take_out_the_garbage.control_to_trash_bin import ControlToTrashBin
 
 from ed_msgs.msg import EntityInfo
@@ -259,7 +259,7 @@ class PickUpTrash(smach.StateMachine):
         :param arm_designator: arm designator resolving to the arm with which to grab
         """
         smach.StateMachine.__init__(self, outcomes=["succeeded", "failed", "aborted"])
-        place_pose_designator = ds.EmptySpotDesignator(robot, trashbin_designator)
+        place_pose_designator = EmptySpotDesignator(robot, trashbin_designator, arm_designator)
 
         with self:
             # @cb_interface(outcomes=['done'])

--- a/robot_smach_states/src/robot_smach_states/manipulation/place_designator.py
+++ b/robot_smach_states/src/robot_smach_states/manipulation/place_designator.py
@@ -24,7 +24,7 @@ class EmptySpotDesignator(Designator):
     PLACE_SHELF = "shelf2"
     cabinet = ds.EntityByIdDesignator(robot, id=CABINET, name="pick_shelf")
     arm = ds.UnoccupiedArmDesignator(robot, {})
-    place_position = ds.LockingDesignator(ds.EmptySpotDesignator(robot, cabinet, arm, name="placement", area=PLACE_SHELF),
+    place_position = ds.LockingDesignator(EmptySpotDesignator(robot, cabinet, arm, name="placement", area=PLACE_SHELF),
                                           name="place_position")
     """
 


### PR DESCRIPTION
When merging our emptyspotdesignator we forgot to update some of the imports in challenges. Since the emptyspotdesignator is no longer with the other designators it cannot be imported as ds.Emptyspotdesignator