### PR TITLE
changed default radius to inf

### DIFF
--- a/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
@@ -27,7 +27,7 @@ class EdEntityCollectionDesignator(Designator):
     >>> check_resolve_type(entities, [Entity]) #This is more a test for check_resolve_type to be honest :-/
     """
 
-    def __init__(self, robot, type="", center_point=None, radius=0, id="", parse=True, criteriafuncs=None,
+    def __init__(self, robot, type="", center_point=None, radius=float('inf'), id="", parse=True, criteriafuncs=None,
                  type_designator=None, center_point_designator=None, id_designator=None, debug=False, name=None):
         """Designates a collection of entities of some type, within a radius of some center_point, with some id,
         that match some given criteria functions.
@@ -102,7 +102,7 @@ class EdEntityDesignator(Designator):
     Resolves to an entity from an Ed query
     """
 
-    def __init__(self, robot, type="", center_point=None, radius=0, id="", parse=True, criteriafuncs=None,
+    def __init__(self, robot, type="", center_point=None, radius=float('inf'), id="", parse=True, criteriafuncs=None,
                  weight_function=None, type_designator=None, center_point_designator=None, id_designator=None,
                  debug=False, name=None):
         """Designates an entity of some type, within a radius of some center_point, with some id,


### PR DESCRIPTION
This is needed since we changed the way ed simple query service interprets radius=0 this used to mean that the position of the object didn't matter but now you need to specify that as radius=inf