### PR TITLE
(designators) explicit return None in locking designator

### DIFF
--- a/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
+++ b/robot_smach_states/src/robot_smach_states/util/designators/ed_designators.py
@@ -306,6 +306,8 @@ class LockToId(Designator):
                 if entity:  # If we can find what to remember
                     self._locked_to_id = entity.id  # remember its ID.
                     return entity
+                else:
+                    return None
             else:  # If we do remember something already, recall that remembered ID:
                 return self.robot.ed.get_entity(id=self._locked_to_id)
         else:


### PR DESCRIPTION
As suggested by @alberth in https://github.com/tue-robotics/tue_robocup/pull/1033/files#r424597213