### PR TITLE
fix missing offset parameter

### DIFF
--- a/robot_skills/src/robot_skills/arm/arms.py
+++ b/robot_skills/src/robot_skills/arm/arms.py
@@ -295,6 +295,10 @@ class Arm(RobotPart):
         self._operational = True  # In simulation, there will be no hardware cb
 
         # Get stuff from the parameter server
+        offset = self.load_param('skills/arm/' + self.side + '/grasp_offset/')
+        self.offset = kdl.Frame(kdl.Rotation.RPY(offset["roll"], offset["pitch"], offset["yaw"]),
+                                kdl.Vector(offset["x"], offset["y"], offset["z"]))
+
         self.marker_to_grippoint_offset = self.load_param('skills/arm/' + self.side + '/marker_to_grippoint')
 
         # Grasp offsets


### PR DESCRIPTION
This thing got lost in the composable robot interface. I don't know how its possible that this bug never surfaced during any tests but it needs to be fixed. 
Without this parameter arm.send_goal **does not** work