### PR TITLE
remove look_at_hand function

### DIFF
--- a/challenge_presentation/src/challenge_presentation/presentation.py
+++ b/challenge_presentation/src/challenge_presentation/presentation.py
@@ -5,6 +5,8 @@ from functools import partial
 # TU/e Robotics
 from robot_smach_states.utility import Initialize
 import robot_skills.arm.arms as arms
+from robot_skills.util.kdl_conversions import VectorStamped
+
 
 class English(object):
     HI_MY_NAME_IS = "Hello, my name is {}"
@@ -134,9 +136,11 @@ class Presentation(smach.State):
         #Removed this part to increase the tempo of the presentation
         # function_list.append(partial(self.right_arm.send_joint_trajectory, "point_to_kinect"))
         function_list.append(partial(self.robot.speech.speak, self.trans.CAMERA, language=self.language, voice=self.voice, block=False))
-        function_list.append(partial(self.robot.head.look_at_hand, "right"))
+        function_list.append(partial(self.robot.head.look_at_point,
+                                     VectorStamped(1.0, 1.0, 1.5, frame_id="/"+self.robot.robot_name+"/base_link")))
         function_list.append(partial(self.robot.head.wait_for_motion_done))
-        function_list.append(partial(self.robot.head.look_at_hand, "left"))
+        function_list.append(partial(self.robot.head.look_at_point,
+                                     VectorStamped(1.0, -1.0, 1.5, frame_id="/"+self.robot.robot_name+"/base_link")))
         function_list.append(partial(self.robot.head.wait_for_motion_done))
         function_list.append(partial(self.robot.head.reset))
         function_list.append(partial(self.robot.head.wait_for_motion_done))

--- a/robot_skills/src/robot_skills/head.py
+++ b/robot_skills/src/robot_skills/head.py
@@ -31,19 +31,6 @@ class Head(RobotPart):
 
         return self.look_at_point(reset_goal, timeout=timeout)
 
-    def look_at_hand(self, side):
-        """
-        Look at the left or right hand, expects string "left" or "right"
-        Optionally, keep tracking can be disabled (keep_tracking=False)
-        """
-        if side == "left":
-            return self.look_at_point(VectorStamped(0, 0, 0, frame_id="/"+self.robot_name+"/grippoint_left"))
-        elif side == "right":
-            return self.look_at_point(VectorStamped(0, 0, 0, frame_id="/"+self.robot_name+"/grippoint_right"))
-        else:
-            rospy.logerr("No side specified for look_at_hand. Give me 'left' or 'right'")
-            return False
-
     def look_at_ground_in_front_of_robot(self, distance=2):
         goal = VectorStamped(x=distance, frame_id="/"+self.robot_name+"/base_link")
 

--- a/robot_skills/src/robot_skills/mockbot.py
+++ b/robot_skills/src/robot_skills/mockbot.py
@@ -224,7 +224,6 @@ class Head(MockedRobotPart):
         self.send_goal = AlteredMagicMock()
         self.cancel_goal = AlteredMagicMock()
         self.reset = AlteredMagicMock()
-        self.look_at_hand = AlteredMagicMock()
         self.wait = AlteredMagicMock()
         self.getGoal = AlteredMagicMock()
         self.atGoal = AlteredMagicMock()


### PR DESCRIPTION
This function is not used in any challenges besides the presentation. Where it can easily be removed as it is only used to show that the camera can move around.