### PR TITLE
allow direct access to arm parts

### DIFF
--- a/robot_skills/src/robot_skills/robot.py
+++ b/robot_skills/src/robot_skills/robot.py
@@ -99,9 +99,8 @@ class Robot(object):
         :param arm_name: Name of the arm part.
         :param arm_part: Arm part object
         """
-        # Don't add the arm to the robot object to avoid direct access from challenge code.
-        self.parts[arm_name] = arm_part
         self._arms[arm_name] = arm_part
+        self.add_body_part(arm_name, arm_part)
 
     @property
     def arms(self):


### PR DESCRIPTION
Previously we restricted access to the arm parts of the robot. This was so that challenge developers could not introduce robot-specific solutions. While I think this is a good philosophy for reusable solutions like the smach states I think for challenges we should make the direct robot interface more user friendly. 

We have often bypassed this restriction in challenges by simply calling the arm via hero.parts['center_arm']