### PR TITLE
CI Improvement/fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,13 +19,18 @@ jobs:
     condition: and(succeeded(), not(canceled()))
     steps:
       - task: Bash@3
-        displayName: 'Determine packages to be build'
-        name: matrix
+        displayName: 'Get CI scripts'
         inputs:
           targetType: 'inline'
           script: |
             wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/packages.sh
             wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/azure_commit_range.py
+      - task: Bash@3
+        displayName: 'Determine packages to be build'
+        name: matrix
+        inputs:
+          targetType: 'inline'
+          script: |
             export COMMIT_RANGE=$(python3 ./azure_commit_range.py)
             ALL=$([ $BUILD_REASON == "Schedule" ] && echo "true")
             source ./packages.sh --pullrequest=${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-false} --branch=$SYSTEM_PULLREQUEST_TARGETBRANCH --commit-range=$COMMIT_RANGE --all=$ALL tue_robocup challenge_following_and_guiding challenge_manipulation challenge_navigation challenge_person_recognition challenge_spr challenge_speech_recognition

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,31 +56,31 @@ jobs:
       displayName: 'Get CI scripts'
       condition: and(succeeded(), not(canceled()))
     - task: Bash@3
+      displayName: 'Set Branch'
       inputs:
         targetType: 'inline'
         script: |
           source ./set-branch.sh --branch=${SYSTEM_PULLREQUEST_TARGETBRANCH:-${BUILD_SOURCEBRANCH#refs/heads/}}
           echo "##vso[task.setvariable variable=BRANCH]$BRANCH"
-      displayName: 'Set Branch'
       condition: and(succeeded(), not(canceled()))
     - task: Bash@3
+      displayName: 'Install'
       inputs:
         targetType: 'inline'
         script: |
           bash install-package.sh --package=$PACKAGE --branch=$BRANCH --commit=$BUILD_SOURCEVERSION --pullrequest=${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-false} --image="tuerobotics/tue-env"
-      displayName: 'Install'
       condition: and(succeeded(), not(canceled()))
     - task: Bash@3
+      displayName: 'Build'
       inputs:
         targetType: 'inline'
         script: |
           bash build-package.sh --package=$PACKAGE
-      displayName: 'Build'
       condition: and(succeeded(), not(canceled()))
     - task: Bash@3
+      displayName: 'Test'
       inputs:
         targetType: 'inline'
         script: |
           bash test-package.sh --package=$PACKAGE
-      displayName: 'Test'
       condition: and(succeeded(), not(canceled()))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,8 +2,8 @@ trigger:
   batch: true
 
 schedules:
-  - cron: "0 1 * * *"
-    displayName: "Nightly"
+  - cron: '0 1 * * *'
+    displayName: 'Nightly'
     branches:
       include:
         - master

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,8 @@ jobs:
         inputs:
           targetType: 'inline'
           script: |
-            wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/packages.sh
-            wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/azure_commit_range.py
+            wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/packages.sh
+            wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/azure_commit_range.py
             export COMMIT_RANGE=$(python3 ./azure_commit_range.py)
             ALL=$([ $BUILD_REASON == "Schedule" ] && echo "true")
             source ./packages.sh --pullrequest=${SYSTEM_PULLREQUEST_PULLREQUESTNUMBER:-false} --branch=$SYSTEM_PULLREQUEST_TARGETBRANCH --commit-range=$COMMIT_RANGE --all=$ALL tue_robocup challenge_following_and_guiding challenge_manipulation challenge_navigation challenge_person_recognition challenge_spr challenge_speech_recognition
@@ -44,10 +44,10 @@ jobs:
       inputs:
         targetType: 'inline'
         script: |
-          wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/install-package.sh
-          wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/build-package.sh
-          wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/test-package.sh
-          wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/set-branch.sh
+          wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/install-package.sh
+          wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/build-package.sh
+          wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/test-package.sh
+          wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/set-branch.sh
       displayName: 'Get CI scripts'
       condition: and(succeeded(), not(canceled()))
     - task: Bash@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,10 @@ variables:
 
 jobs:
   - job: package_selection
-    displayName: 'Package selection'
+    ${{ if eq(variables['Build.Reason'], 'PullRequest')}}:
+      displayName: 'Package selection (PR)'
+    ${{ else }}:
+      displayName: 'Package selection'
     pool:
       vmImage: 'ubuntu latest'
     condition: and(succeeded(), not(canceled()))
@@ -37,7 +40,10 @@ jobs:
             echo "##vso[task.setVariable variable=json_string;isOutput=true]$PACKAGES_DICT"
 
   - job: install_build_test
-    displayName: 'Install, build & test:'
+    ${{ if eq(variables['Build.Reason'], 'PullRequest')}}:
+      displayName: 'Install, build & test (PR):'
+    ${{ else }}:
+      displayName: 'Install, build & test:'
     pool:
       vmImage: 'ubuntu latest'
     dependsOn: package_selection

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,8 +26,8 @@ jobs:
         inputs:
           targetType: 'inline'
           script: |
-            wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/packages.sh
-            wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/azure_commit_range.py
+            wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/packages.sh
+            wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/azure_commit_range.py
       - task: Bash@3
         displayName: 'Determine packages to be build'
         name: matrix
@@ -55,10 +55,10 @@ jobs:
       inputs:
         targetType: 'inline'
         script: |
-          wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/install-package.sh
-          wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/build-package.sh
-          wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/test-package.sh
-          wget https://raw.githubusercontent.com/tue-robotics/tue-env/ci/azure/ci/set-branch.sh
+          wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/install-package.sh
+          wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/build-package.sh
+          wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/test-package.sh
+          wget https://raw.githubusercontent.com/tue-robotics/tue-env/master/ci/set-branch.sh
       displayName: 'Get CI scripts'
       condition: and(succeeded(), not(canceled()))
     - task: Bash@3


### PR DESCRIPTION
The status checks only showed PR or push tests, because they had the same name. By changing the displayName, both show in the status checks. Which makes merging much safer, as I think often people forgot to check the other tests on azure.