### PR TITLE
remove leading and trailing quotes

### DIFF
--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -156,6 +156,8 @@ def main():
 
         # Dump the output json object to a string
         task_specification = json.dumps(semantics)
+        task_specification = task_specification[1:-1] # remove leading and trailing quotes
+        rospy.loginfo("Sending task: {}".format(task_specification))
 
         # Send the task specification to the action server
         task_result = action_client.send_task(task_specification)

--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -156,7 +156,7 @@ def main():
 
         # Dump the output json object to a string
         task_specification = json.dumps(semantics)
-        task_specification = task_specification[1:-1] # remove leading and trailing quotes
+        task_specification = task_specification.strip() # remove leading and trailing quotes
         rospy.loginfo("Sending task: {}".format(task_specification))
 
         # Send the task specification to the action server


### PR DESCRIPTION
Task specification was a string with value "action_recipe"
Should be: action_recipe
Difficult to write down. It had ascii double quotes at the start and end of the string