### PR TITLE
Receptionist fix drink designators

### DIFF
--- a/challenge_receptionist/src/challenge_receptionist/learn_guest.py
+++ b/challenge_receptionist/src/challenge_receptionist/learn_guest.py
@@ -32,7 +32,7 @@ class LearnGuest(smach.StateMachine):
 
         self.drink_spec_des = ds.Designator(challenge_knowledge.common.drink_spec, name='drink_spec')
         guest_drink_hmi_des = ds.VariableDesignator(resolve_type=HMIResult, name='guest_drink')
-        guest_drink_name_des = ds.FieldOfHMIResult(guest_drink_des, semantics_path='drink', name='guest_drinkname')
+        guest_drink_name_des = ds.FieldOfHMIResult(guest_drink_hmi_des, semantics_path='drink', name='guest_drinkname')
 
         with self:
             smach.StateMachine.add('GOTO_DOOR',
@@ -108,7 +108,7 @@ class LearnGuest(smach.StateMachine):
                                                 'no_result': 'SAY_DRINK_QUESTION'})
 
             @cb_interface(outcomes=['done'])
-            def _write_drink_name(answer, drink_name_designator):
+            def _write_drink_name(ud, answer, drink_name_designator):
                 name = answer.resolve()
                 drink_name_designator.write(name)
                 return 'done'

--- a/challenge_receptionist/src/challenge_receptionist/receptionist.py
+++ b/challenge_receptionist/src/challenge_receptionist/receptionist.py
@@ -31,8 +31,7 @@ class HandleSingleGuest(smach.StateMachine):
 
         guest_entity_des = ds.VariableDesignator(resolve_type=Entity, name='guest_entity')
         guest_name_des = ds.VariableDesignator('guest 1', name='guest_name')
-        guest_drink_des = ds.VariableDesignator(resolve_type=HMIResult, name='guest_drink')
-        guest_drinkname_des = ds.FieldOfHMIResult(guest_drink_des, semantics_path='drink', name='guest_drinkname')
+        guest_drink_des = ds.VariableDesignator('drink', name='guest_drink')
 
         with self:
             smach.StateMachine.add('LEARN_GUEST',
@@ -47,7 +46,7 @@ class HandleSingleGuest(smach.StateMachine):
 
             smach.StateMachine.add('SAY_GOTO_OPERATOR',
                                    Say(robot, ["Okidoki, you are {name} and you like {drink}, lets go inside. Please follow me"],
-                                                       name=guest_name_des, drink=guest_drinkname_des,
+                                                       name=guest_name_des, drink=guest_drink_des,
                                                        block=True,
                                                        look_at_standing_person=True),
                                    transitions={'spoken': 'GOTO_LIVINGROOM'})
@@ -64,7 +63,7 @@ class HandleSingleGuest(smach.StateMachine):
                                    IntroduceGuest(robot,
                                                   guest_entity_des,
                                                   guest_name_des,
-                                                  guest_drinkname_des,
+                                                  guest_drink_des,
                                                   assume_john=assume_john),
                                    transitions={'succeeded': 'FIND_SEAT_FOR_GUEST',
                                                 'abort': 'FIND_SEAT_FOR_GUEST'})


### PR DESCRIPTION
Fix for the robot saying 'you are paul and you like [None]'
this was caused because `guest_drink_des` was redefined locally rather than using the input. 

I made it so that we pass the drink as a string variable rather than a HMI result as I think this makes processing the information less comples. After all, it does not matter how we know the persons favourite drink

This change was tested on the robot and the speech regarding the drink works as it should now. (the robot still cant hear very well)