### PR TITLE
Fix/grasping benchmark

### DIFF
--- a/robot_smach_states/benchmark/benchmark_grasping.py
+++ b/robot_smach_states/benchmark/benchmark_grasping.py
@@ -111,10 +111,10 @@ def single_item(robot, results_writer, cls, support, waypoint, inspect_from_area
 
                 entity = grasp_entity.resolve()  # type: Entity
                 if entity:
-                    vector_stamped = entity.pose  # type: VectorStamped
-                    record['x'] = '{:.3f}'.format(vector_stamped.vector.x())
-                    record['y'] = '{:.3f}'.format(vector_stamped.vector.y())
-                    record['z'] = '{:.3f}'.format(vector_stamped.vector.z())
+                    frame_stamped = entity.pose  # type: VectorStamped
+                    record['x'] = '{:.3f}'.format(frame_stamped.frame.p.x())
+                    record['y'] = '{:.3f}'.format(frame_stamped.frame.p.y())
+                    record['z'] = '{:.3f}'.format(frame_stamped.frame.p.z())
 
                 grab_state = Grab(robot, grasp_entity, arm)
 

--- a/robot_smach_states/benchmark/benchmark_grasping.py
+++ b/robot_smach_states/benchmark/benchmark_grasping.py
@@ -111,7 +111,7 @@ def single_item(robot, results_writer, cls, support, waypoint, inspect_from_area
 
                 entity = grasp_entity.resolve()  # type: Entity
                 if entity:
-                    frame_stamped = entity.pose  # type: VectorStamped
+                    frame_stamped = entity.pose  # type: FrameStamped
                     record['x'] = '{:.3f}'.format(frame_stamped.frame.p.x())
                     record['y'] = '{:.3f}'.format(frame_stamped.frame.p.y())
                     record['z'] = '{:.3f}'.format(frame_stamped.frame.p.z())

--- a/robot_smach_states/benchmark/benchmark_grasping.py
+++ b/robot_smach_states/benchmark/benchmark_grasping.py
@@ -144,7 +144,7 @@ def single_item(robot, results_writer, cls, support, waypoint, inspect_from_area
         else:
             rospy.logerr("No entities found at all :-(")
     except AssertionError as assertion_err:
-        say_fail = Say(robot, sentence=assertion_err.message + ", sorry")
+        say_fail = Say(robot, sentence=(str(assertion_err) + ", sorry"))
         say_fail.execute()
     finally:
         results_writer.writerow(record)

--- a/robot_smach_states/benchmark/grasp_benchmark_config.csv
+++ b/robot_smach_states/benchmark/grasp_benchmark_config.csv
@@ -1,5 +1,5 @@
 cls,support,waypoint,inspect_from_area,search_area
-mentos,bar,explore10,in_front_of,on_top_of
-fanta,couch,entry_point,in_front_of,on_top_of
-hairspray,cabinet,explore1,in_front_of,on_top_of
-coke,dinner_table,help_me_carry_starting_point,in_front_of,on_top_of
+coke,dinner_table,rips_point_1,in_front_of,on_top_of
+mentos,bar,rips_point_1,in_front_of,on_top_of
+fanta,couch,rips_point_1,in_front_of,on_top_of
+hairspray,cabinet,rips_point_1,in_front_of,on_top_of


### PR DESCRIPTION
tested the grasping benchmark. Which was broken. 
Fixed proper handling of assertionerrors
usage of framestamped for saving data
and used waypoints that exist in the impuls environment. (note it is not stated that the benchmark test needs to be performed in this environment specifically in the docs, imo this should be done in a readme/wiki on how to run the benchmark test)