### PR TITLE
Demo peter

### DIFF
--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -123,7 +123,7 @@ def main():
                                    etype="waypoint")
 
             # Listen for the new task
-            while True:
+            for i in range(timeout_count):
                 try:
                     if is_sim_mode():
                         sentence, semantics = robot.hmi.query(description="",
@@ -132,14 +132,12 @@ def main():
                     else:
                         sentence, semantics = robot.picovoice.get_intent("demo", demo=True)
                         semantics = create_semantics(semantics)
-                    timeout_count = 0
                     break
                 except hmi.TimeoutException:
                     robot.speech.speak(random.sample(knowledge.not_understood_sentences, 1)[0])
-                    timeout_count += 1
-                    if timeout_count >= 3:
-                        rospy.logwarn("[GPSR] Timeout_count: {}".format(timeout_count))
-                        break
+            else:
+                rospy.logwarn("[GPSR] Timeout_count: {}".format(timeout_count))
+                break
 
             # check if we have heard this correctly
             robot.speech.speak('I heard %s, is this correct?' % sentence)
@@ -156,7 +154,7 @@ def main():
                     robot.speech.speak('Sorry')
                     continue
             except hmi.TimeoutException:
-                # robot did not hear the confirmation, so lets assume its correct
+                rospy.loginfo("robot did not hear the confirmation, so lets assume its correct")
                 break
 
             break

--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -168,7 +168,7 @@ def main():
         # Send the task specification to the action server
         task_result = action_client.send_task(task_specification)
 
-        rospy.loginfo(f"{task_result.missing_field}")
+        rospy.loginfo(f"{task_result.missing_field=}")
         # # Ask for missing information
         # while task_result.missing_field:
         #     request_missing_field(knowledge.task_result.missing_field)

--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -106,7 +106,6 @@ def main():
         # Report to the user
         robot.head.look_at_standing_person()
         robot.speech.speak(report, block=True)
-        timeout_count = 0
 
         while True:
             rospy.loginfo("Waiting for trigger")
@@ -123,7 +122,8 @@ def main():
                                    etype="waypoint")
 
             # Listen for the new task
-            for i in range(timeout_count):
+            timeout_tries = 3
+            for i in range(timeout_tries):
                 try:
                     if is_sim_mode():
                         sentence, semantics = robot.hmi.query(description="",
@@ -136,8 +136,9 @@ def main():
                 except hmi.TimeoutException:
                     robot.speech.speak(random.sample(knowledge.not_understood_sentences, 1)[0])
             else:
-                rospy.logwarn("[GPSR] Timeout_count: {}".format(timeout_count))
-                break
+                rospy.logwarn("[GPSR] speech timed out {timeout_tries} times, aborting")
+                robot.speech.speak("I am sorry but I cannot hear you. Let's not try again.")
+                continue
 
             # check if we have heard this correctly
             robot.speech.speak('I heard %s, is this correct?' % sentence)

--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -138,7 +138,7 @@ def main():
             else:
                 rospy.logwarn("[GPSR] speech timed out {timeout_tries} times, aborting")
                 robot.speech.speak("I am sorry but I cannot hear you. Let's not try again.")
-                continue
+                continue  # Continue the outer while loop
 
             # check if we have heard this correctly
             robot.speech.speak('I heard %s, is this correct?' % sentence)

--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -113,7 +113,7 @@ def main():
 
             robot.speech.speak(user_instruction, block=True)
             rospy.loginfo("Waiting for trigger")
-            #trigger.execute()
+            trigger.execute()
 
             base_loc = robot.base.get_location()
             base_pose = base_loc.frame

--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -168,7 +168,7 @@ def main():
         # Send the task specification to the action server
         task_result = action_client.send_task(task_specification)
 
-        print(task_result.missing_field)
+        rospy.loginfo(f"{task_result.missing_field}")
         # # Ask for missing information
         # while task_result.missing_field:
         #     request_missing_field(knowledge.task_result.missing_field)

--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -109,11 +109,11 @@ def main():
         timeout_count = 0
 
         while True:
-            robot.head.look_at_standing_person()
-
-            robot.speech.speak(user_instruction, block=True)
             rospy.loginfo("Waiting for trigger")
             trigger.execute()
+
+            robot.head.look_at_standing_person()
+            robot.speech.speak(user_instruction, block=True)
 
             base_loc = robot.base.get_location()
             base_pose = base_loc.frame

--- a/challenge_demo/scripts/demo.py
+++ b/challenge_demo/scripts/demo.py
@@ -92,7 +92,7 @@ def main():
 
     trigger = WaitForTrigger(robot, ["gpsr"], "/" + robot_name + "/trigger")
 
-    while True:
+    while not rospy.is_shutdown():
         # Navigate to the GPSR meeting point
         if not skip:
             robot.speech.speak("Moving to the meeting point.", block=False)
@@ -107,7 +107,7 @@ def main():
         robot.head.look_at_standing_person()
         robot.speech.speak(report, block=True)
 
-        while True:
+        while not rospy.is_shutdown():
             rospy.loginfo("Waiting for trigger")
             trigger.execute()
 


### PR DESCRIPTION
Some suggestions based on our demo today. Fixes the following problems:

1. reinstates wait for trigger. I find this useful for demos since the presenter can determine the tempo of the presentation. Otherwise the robot is constantly asking for validation. 
2. Fix the timeout logic for not hearing the operator. Previous implementation just continued with the loop which crashes if the sentence parameter was not initialised. Otherwise it will just redo the previous command. Now it says "oops we couldn't do it." and waits for the next trigger.